### PR TITLE
New flag on deploy: --affiliation.

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -29,6 +29,7 @@ var overrideJson []string
 var deployAllFlag bool
 var forceDeployFlag bool
 var deployVersion string
+var deployAffiliation string
 
 // deployCmd represents the deploy command
 var deployCmd = &cobra.Command{
@@ -89,7 +90,7 @@ The --force flag will override this, and execute the deploy without confirmation
 			Configuration: config,
 		}
 
-		output, err := deploy.ExecuteDeploy(args, overrideJson, appList, envList, &persistentOptions, localDryRun, deployAllFlag, forceDeployFlag, deployVersion)
+		output, err := deploy.ExecuteDeploy(args, overrideJson, appList, envList, &persistentOptions, localDryRun, deployAllFlag, forceDeployFlag, deployVersion, deployAffiliation)
 		if err != nil {
 			l := log.New(os.Stderr, "", 0)
 			l.Println(err.Error())
@@ -128,15 +129,6 @@ func init() {
 		"v", "", "Will update the version tag in the app of base configuration file prior to deploy, depending on which file contains the version tag.  If both files "+
 			"files contains the tag, the tag will be updated in the app configuration file.")
 
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// deployCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// deployCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	// File flag, supports multiple instances of the flag
-
+	deployCmd.Flags().StringVarP(&deployAffiliation, "affiliation",
+		"", "", "Overrides the logged in affiliation")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,14 +4,15 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/skatteetaten/ao/pkg/cmdoptions"
+	"github.com/skatteetaten/ao/pkg/configuration"
 	"github.com/skatteetaten/ao/pkg/openshift"
+	"github.com/skatteetaten/ao/pkg/serverapi"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"github.com/skatteetaten/ao/pkg/configuration"
-	"github.com/skatteetaten/ao/pkg/serverapi"
-	"strings"
 	"github.com/stromland/cobra-prompt"
 )
 
@@ -43,7 +44,7 @@ This application has two main parts.
 2. apply the aoc configuration to the clusters
 `,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		commandsWithoutLogin := []string{"login", "logout", "version", "update", "help"}
+		commandsWithoutLogin := []string{"login", "logout", "version", "update", "help", "deploy"}
 
 		commands := strings.Split(cmd.CommandPath(), " ")
 		if len(commands) > 1 {

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -71,8 +71,11 @@ func (deploy *DeployClass) generateJson(
 }
 
 func (deploy *DeployClass) ExecuteDeploy(args []string, overrideJsons []string, applist []string, envList []string,
-	persistentOptions *cmdoptions.CommonCommandOptions, localDryRun bool, deployAll bool, force bool, deployVersion string) (output string, err error) {
+	persistentOptions *cmdoptions.CommonCommandOptions, localDryRun bool, deployAll bool, force bool, deployVersion string, affiliation string) (output string, err error) {
 
+	if affiliation != "" {
+		deploy.Configuration.OpenshiftConfig.Affiliation = affiliation
+	}
 	ac, err := auroraconfig.GetAuroraConfig(deploy.Configuration)
 	if err != nil {
 		return "", err
@@ -93,7 +96,7 @@ func (deploy *DeployClass) ExecuteDeploy(args []string, overrideJsons []string, 
 		}
 	}
 
-	var affiliation = deploy.Configuration.GetAffiliation()
+	affiliation = deploy.Configuration.GetAffiliation()
 	jsonStr, err := deploy.generateJson(affiliation, persistentOptions.DryRun)
 	if err != nil {
 		return "", err

--- a/pkg/serverapi/serverapi.go
+++ b/pkg/serverapi/serverapi.go
@@ -373,9 +373,12 @@ func CallApiWithHeaders(headers map[string]string, httpMethod string, apiEndpoin
 						err = errors.New("Boober URL is not configured, please log in again")
 						return outputMap, err
 					}
+					if token == "" {
+						token = openshiftConfig.Clusters[i].Token
+					}
 					output, err := callApiInstance(headers, httpMethod, combindedJson, verbose,
 						openshiftConfig.Clusters[i].BooberUrl+apiEndpoint,
-						openshiftConfig.Clusters[i].Token, dryRun, debug)
+						token, dryRun, debug)
 					outputMap[openshiftConfig.Clusters[i].Name] = output
 
 					if err != nil {


### PR DESCRIPTION
Fixed bug: --token was not recognized
Added deploy to list of commands not requiring login.