### PR TITLE
Aos 2301 login

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -11,8 +11,9 @@ import (
 )
 
 var (
-	flagUserName  string
-	flagLocalhost bool
+	flagUserName   string
+	flagLocalhost  bool
+	flagApiCluster string
 )
 
 var loginCmd = &cobra.Command{
@@ -27,6 +28,7 @@ func init() {
 	loginCmd.Flags().StringVarP(&flagUserName, "username", "u", user, "the username to log in with, standard is $USER")
 	loginCmd.Flags().BoolVarP(&flagLocalhost, "localhost", "", false, "set api to localhost")
 	loginCmd.Flags().MarkHidden("localhost")
+	loginCmd.Flags().StringVarP(&flagApiCluster, "apicluster", "", "", "Select specified API cluster")
 }
 
 func Login(cmd *cobra.Command, args []string) error {

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -2,10 +2,12 @@ package config
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // The version variables will be set during build time, see build/build.sh
@@ -36,6 +38,10 @@ type AOVersion struct {
 }
 
 func (v *AOVersion) IsNewVersion() bool {
+	// No new version if current version is dirty
+	if strings.Contains(Version, "-dirty") {
+		return false
+	}
 	// TODO: Should do better check then this
 	return v.Version != Version
 }


### PR DESCRIPTION
Added apicluster flag.
Suppress check for update if current version is "-dirty" (means local development)
Suppress check for legal AuroraConfig if localhost does not answer (no boober running locally)
Suppress check for legal AuroraConfig if we change API cluster - irrelevant (and complicated to reset host, no need since this is a development feature only)
If user does not specify an AuroraConfig, but its in the config file, we just use the one from the config file.