### PR TITLE
Aos 2299 macos build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,8 +24,7 @@ node {
     }
 
     stage('Copy ao to assets') {
-        sh 'mkdir ./website/public/assets'
-        sh 'mkdir ./website/public/assets/darwin'
+        sh 'mkdir -p ./website/public/assets/darwin'
         sh './.go/bin/ao version --json > ./website/public/assets/version.json'
         sh 'cp ./.go/bin/ao ./website/public/assets'
         sh 'cp ./.go/bin/darwin_amd64/ao ./website/public/assetts/darwin'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ node {
         sh 'mkdir ./website/public/assets'
         sh './bin/amd64/ao version --json > ./website/public/assets/version.json'
         sh 'cp ./bin/amd64/ao ./website/public/assets'
+        sh 'cp ./bin/darwin_amd64/ao ./website/public/assetts/darwin_ao'
     }
 
     String version = git.getTagFromCommit()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,11 +26,9 @@ node {
     stage('Copy ao to assets') {
         sh 'mkdir ./website/public/assets'
         sh 'mkdir ./website/public/assets/darwin'
-        sh './bin/amd64/ao version --json > ./website/public/assets/version.json'
-        sh 'cp ./bin/amd64/ao ./website/public/assets'
-        sh 'ls .bin/darwin_amd64'
-        sh 'ls .website/public/assets'
-        sh 'cp ./bin/darwin_amd64/ao ./website/public/assetts/darwin'
+        sh './.go/bin/ao version --json > ./website/public/assets/version.json'
+        sh 'cp ./.go/bin/ao ./website/public/assets'
+        sh 'cp ./.go/bin/darwin_amd64/ao ./website/public/assetts/darwin'
     }
 
     String version = git.getTagFromCommit()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ node {
         sh 'mkdir -p ./website/public/assets/darwin'
         sh './.go/bin/ao version --json > ./website/public/assets/version.json'
         sh 'cp ./.go/bin/ao ./website/public/assets'
+        sh 'ls ./.go/bin'
         sh 'cp ./.go/bin/darwin_amd64/ao ./website/public/assetts/darwin'
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,8 @@ node {
         sh 'mkdir ./website/public/assets/darwin'
         sh './bin/amd64/ao version --json > ./website/public/assets/version.json'
         sh 'cp ./bin/amd64/ao ./website/public/assets'
+        sh 'ls .bin/darwin_amd64'
+        sh 'ls .website/public/assets'
         sh 'cp ./bin/darwin_amd64/ao ./website/public/assetts/darwin'
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,11 +24,10 @@ node {
     }
 
     stage('Copy ao to assets') {
-        sh 'mkdir -p ./website/public/assets/darwin'
+        sh 'mkdir -p ./website/public/assets/macos'
         sh './.go/bin/ao version --json > ./website/public/assets/version.json'
         sh 'cp ./.go/bin/ao ./website/public/assets'
-        sh 'ls ./.go/bin'
-        sh 'cp ./.go/bin/darwin_amd64/ao ./website/public/assetts/darwin'
+        sh 'cp ./.go/bin/darwin_amd64/ao ./website/public/assets/macos'
     }
 
     String version = git.getTagFromCommit()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,9 +25,10 @@ node {
 
     stage('Copy ao to assets') {
         sh 'mkdir ./website/public/assets'
+        sh 'mkdir ./website/public/assets/darwin'
         sh './bin/amd64/ao version --json > ./website/public/assets/version.json'
         sh 'cp ./bin/amd64/ao ./website/public/assets'
-        sh 'cp ./bin/darwin_amd64/ao ./website/public/assetts/darwin_ao'
+        sh 'cp ./bin/darwin_amd64/ao ./website/public/assetts/darwin'
     }
 
     String version = git.getTagFromCommit()

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,9 @@ GOPATH := $(shell pwd)/.go
 
 GOSRC := $(shell pwd)/.go/src
 
-GOBIN := $(shell pwd)/bin/$(ARCH)
+# GOBIN := $(shell pwd)/bin/$(ARCH)
+# GOBIN-LINUX := $(shell pwd)/bin/linux-$(ARCH)
+# GOBIN-DARWIN := $(shell pwd)/bin/darwin-$(ARCH)
 
 VERSION := $(shell git describe --tags --always --dirty)
 
@@ -54,16 +56,35 @@ deps:
 	@glide install
 
 
-build: build-dirs bin-file
+build: build-dirs bin-file-linux bin-file-darwin
 
-bin-file:
-	@echo "Building with GoPath : $(GOPATH) and GoSrc $(GOSRC)"
+bin-file-linux:
+	@echo "Building for Linux with GoPath : $(GOPATH) and GoSrc $(GOSRC)"
 	@/bin/sh -c "                                                          \
 	        cd .go/src/$(PKG);                                             \
 	        GOPATH=$(GOPATH)                                               \
 	        GOSRC=$(GOSRC)                                                 \
-	        GOBIN=$(GOBIN)                                                 \
+			OS=linux													   \
 	        ARCH=$(ARCH)                                                   \
+			OS=linux                                                       \
+	        PKG=$(PKG)                                                     \
+	        VERSION=$(VERSION)                                             \
+	        BRANCH=$(BRANCH)                                               \
+	        BUILDSTAMP=$(BUILDSTAMP)                                       \
+	        GITHASH=$(GITHASH)                                             \
+	        ./build/build.sh                                               \
+	    "
+
+
+bin-file-darwin:
+	@echo "Building for Darwin with GoPath : $(GOPATH) and GoSrc $(GOSRC)"
+	@/bin/sh -c "                                                          \
+	        cd .go/src/$(PKG);                                             \
+	        GOPATH=$(GOPATH)                                               \
+	        GOSRC=$(GOSRC)                                                 \
+			OS=darwin													   \
+	        ARCH=$(ARCH)                                                   \
+			OS=darwin                                                      \
 	        PKG=$(PKG)                                                     \
 	        VERSION=$(VERSION)                                             \
 	        BRANCH=$(BRANCH)                                               \
@@ -82,8 +103,9 @@ test: build-dirs
 	    "
 
 build-dirs: .go/src/$(PKG)
-	@mkdir -p bin/$(ARCH)
-	@mkdir -p .go/pkg .go/bin .go/std/$(ARCH)
+	@mkdir -p bin/amd64
+	@mkdir -p bin/darwin_amd64
+	@mkdir -p .go/pkg .go/bin .go/std/linux-$(ARCH) .go/std/darwin_$(ARCH)
 
 .go/src/$(PKG):
 	@mkdir -p .go/src/$(PKG)

--- a/build/build.sh
+++ b/build/build.sh
@@ -41,10 +41,14 @@ if [ -z "${BRANCH}" ]; then
     echo "BRANCH must be set"
     exit 1
 fi
-
+if [ -z "${OS}" ]; then
+    echo "OS must be set"
+    exit 1
+fi
 
 export CGO_ENABLED=0
 export GOARCH="${ARCH}"
+export GOOS="${OS}"
 
 #
 # We have a lot of dependencies. If we use ./... we need to import the whole world.
@@ -57,4 +61,9 @@ go install                                                         \
     -gcflags='-B -l' \
     -pkgdir=${GOPATH}/pkg \
     ${PACKAGES}
+if [ "${OS}" == "darwin" ]; then
+    cp .go/bin/darwin_amd64/ao bin/darwin_amd64/ao
+else
+    cp .go/bin/ao bin/amd64/ao
+fi
 


### PR DESCRIPTION
Added cross-compile for OS=darwin (macos)
Added copying of darwin to assets
Removed the use of GOBIN to control where the executable goes, as this is not supported in cross-platform builds.  Used cp statements in build.sh instead.  