### PR TITLE
Fixed GOBIN issue

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -55,6 +55,9 @@ export GOOS="${OS}"
 # So for now, we filter on our own dependencies
 #
 
+# Need to unset GOBIN to support cross-compiled binaries
+unset GOBIN
+
 PACKAGES=$(go list ./... | grep "ao/pkg\|ao$\|ao/cmd" | xargs echo)
 go install                                                         \
     -ldflags "-X \"${PKG}/pkg/config.Version=${VERSION}\" -X \"${PKG}/pkg/config.Branch=${BRANCH}\" -X \"${PKG}/pkg/config.BuildStamp=${BUILDSTAMP}\" -X \"${PKG}/pkg/config.GitHash=${GITHASH}\"" \


### PR DESCRIPTION
Make failed if GOBIN was set because the binary was not found where expected.  
Also, cross-compiling does not support GOBIN