### PR TITLE
Added check for reachable clusterUrl before setting a cluster to reachable

### DIFF
--- a/pkg/config/openshift.go
+++ b/pkg/config/openshift.go
@@ -46,11 +46,15 @@ func (ao *AOConfig) InitClusters() {
 	for _, cluster := range ao.AvailableClusters {
 		name := cluster
 		booberURL := fmt.Sprintf(ao.BooberUrlPattern, name)
+		clusterURL := fmt.Sprintf(ao.ClusterUrlPattern, name)
 		go func() {
 			reachable := false
 			resp, _ := client.Get(booberURL)
 			if resp != nil && resp.StatusCode < 500 {
-				reachable = true
+				resp, _ := client.Get(clusterURL)
+				if resp != nil && resp.StatusCode < 500 {
+					reachable = true
+				}
 			}
 			logrus.WithField("reachable", reachable).Info(booberURL)
 			ch <- &Cluster{


### PR DESCRIPTION
In addition to checking the booberURL before setting a cluster to reachable in the config file, we also need to verify that the clusterURL is reachable.  