### PR TITLE
AOS-3030 Split cmd.deploy, and added tests

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -457,17 +457,17 @@ func getAPIClient(auroraConfig, overrideToken, overrideCluster string) (*client.
 }
 
 func getDeployClient(unit *deploymentUnit) client.DeployClient {
-	var updateClient *client.ApiClient
+	var deployClient *client.ApiClient
 	if AO.Localhost {
-		updateClient = DefaultApiClient
-		updateClient.Affiliation = unit.auroraConfig
+		deployClient = DefaultApiClient
+		deployClient.Affiliation = unit.auroraConfig
 	} else {
 		token := unit.cluster.Token
 		if unit.overrideToken != "" {
 			token = unit.overrideToken
 		}
-		updateClient = client.NewApiClient(unit.cluster.BooberUrl, token, unit.auroraConfig)
+		deployClient = client.NewApiClient(unit.cluster.BooberUrl, token, unit.auroraConfig, AO.RefName)
 	}
 
-	return updateClient
+	return deployClient
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"regexp"
 	"sort"
 	"strings"
@@ -14,6 +15,18 @@ import (
 	"github.com/skatteetaten/ao/pkg/prompt"
 	"github.com/spf13/cobra"
 )
+
+type deploymentUnitID struct {
+	envName, clusterName string
+}
+
+type deploymentUnit struct {
+	id              *deploymentUnitID
+	applicationList []string
+	cluster         *config.Cluster
+	affiliation     string
+	overrideToken   string
+}
 
 var (
 	flagAffiliation string
@@ -64,6 +77,22 @@ var deployCmd = &cobra.Command{
 	RunE:        deploy,
 }
 
+func newDeploymentUnitID(clusterName, envName string) *deploymentUnitID {
+	return &deploymentUnitID{
+		clusterName: clusterName,
+		envName:     envName,
+	}
+}
+func newDeploymentUnit(unitID *deploymentUnitID, applicationList []string, cluster *config.Cluster, affiliation string, overrideToken string) *deploymentUnit {
+	return &deploymentUnit{
+		id:              unitID,
+		applicationList: applicationList,
+		cluster:         cluster,
+		affiliation:     affiliation,
+		overrideToken:   overrideToken,
+	}
+}
+
 func init() {
 	RootCmd.AddCommand(deployCmd)
 
@@ -86,151 +115,158 @@ func deploy(cmd *cobra.Command, args []string) error {
 		return cmd.Usage()
 	}
 
+	err := validateParams()
+	if err != nil {
+		return err
+	}
+
 	search := args[0]
 	if len(args) == 2 {
 		search = fmt.Sprintf("%s/%s", args[0], args[1])
 	}
 
-	overrides, err := parseOverride(flagOverrides)
+	affiliation := AO.Affiliation
+	if flagAffiliation != "" {
+		affiliation = flagAffiliation
+	}
+
+	apiClient, err := getAPIClient(affiliation, pFlagToken, flagCluster)
 	if err != nil {
 		return err
 	}
 
-	if flagAffiliation == "" {
-		flagAffiliation = AO.Affiliation
-	}
-
-	api := DefaultApiClient
-	api.Affiliation = flagAffiliation
-
-	if flagCluster != "" && !AO.Localhost {
-		c := AO.Clusters[flagCluster]
-		if c == nil {
-			return errors.New("No such cluster " + flagCluster)
-		}
-		if !c.Reachable {
-			return errors.Errorf("%s cluster is not reachable", flagCluster)
-		}
-
-		api.Host = c.BooberUrl
-		api.Token = c.Token
-		if pFlagToken != "" {
-			api.Token = pFlagToken
-		}
-	}
-
-	files, err := api.GetFileNames()
+	applications, err := getApplications(apiClient, search, flagVersion, flagExcludes, cmd.OutOrStdout())
 	if err != nil {
 		return err
-	}
-
-	possibleDeploys := files.GetApplicationIds()
-	applications := fuzzy.SearchForApplications(search, possibleDeploys)
-
-	applications, err = filterExcludes(flagExcludes, applications)
-	if err != nil {
-		return err
-	}
-
-	if len(applications) == 0 {
+	} else if len(applications) == 0 {
 		return errors.New("No applications to deploy")
 	}
 
-	if flagVersion != "" {
-		if len(applications) > 1 {
-			return errors.New("Deploy with version does only support one application")
-		}
-		fileName, err := files.Find(applications[0])
-		if err != nil {
-			return err
-		}
-
-		err = Set(cmd, []string{fileName, "/version", flagVersion})
-		if err != nil {
-			return err
-		}
-	}
-
-	deploySpecs, err := api.GetAuroraDeploySpec(applications, true)
+	filteredDeploymentSpecs, err := getFilteredDeploymentSpecs(apiClient, applications, flagCluster)
 	if err != nil {
 		return err
 	}
-	var filteredDeploymentSpecs []client.AuroraDeploySpec
+
+	overrideConfig, err := parseOverride()
+	if err != nil {
+		return err
+	}
+
+	if !userConfirmation(filteredDeploymentSpecs, cmd.OutOrStdout()) {
+		return errors.New("No applications to deploy")
+	}
+
+	deploymentUnits := createDeploymentUnits(affiliation, pFlagToken, AO.Clusters, filteredDeploymentSpecs)
+
+	result, err := deployToReachableClusters(getDeployClient, deploymentUnits, overrideConfig)
+	if err != nil {
+		return err
+	}
+
+	printDeployResult(result, cmd.OutOrStdout())
+
+	return nil
+}
+
+func validateParams() error {
+
 	if flagCluster != "" {
-		for _, spec := range deploySpecs {
-			if spec.Value("/cluster").(string) == flagCluster {
-				filteredDeploymentSpecs = append(filteredDeploymentSpecs, spec)
-			}
-		}
-	} else {
-		filteredDeploymentSpecs = deploySpecs
-	}
-	header, rows := GetDeploySpecTable(filteredDeploymentSpecs)
-	DefaultTablePrinter(header, rows, cmd.OutOrStdout())
-
-	var filteredApplications []string
-	for _, spec := range filteredDeploymentSpecs {
-		appID := spec.Value("applicationId").(string)
-		filteredApplications = append(filteredApplications, appID)
-	}
-
-	shouldDeploy := true
-	if !flagNoPrompt {
-		defaultAnswer := len(filteredApplications) == 1
-		message := fmt.Sprintf("Do you want to deploy %d application(s)?", len(filteredApplications))
-		shouldDeploy = prompt.Confirm(message, defaultAnswer)
-	}
-
-	if !shouldDeploy {
-		return errors.New("No applications to deploy")
-	}
-
-	payload := client.NewDeployPayload(filteredApplications, overrides)
-
-	var result []*client.DeployResults
-	if AO.Localhost || flagCluster != "" {
-		res, err := api.Deploy(payload)
-		if err != nil {
-			return err
-		}
-		result = append(result, res)
-	} else {
-		result, err = deployToReachableClusters(flagAffiliation, pFlagToken, AO.Clusters, payload)
-		if err != nil {
-			return err
-		}
-	}
-
-	var results []client.DeployResult
-	for _, r := range result {
-		results = append(results, r.Results...)
-	}
-
-	if len(results) == 0 {
-		return errors.New("No deploys were made")
-	}
-
-	sort.Slice(results, func(i, j int) bool {
-		return strings.Compare(results[i].ADS.Name, results[j].ADS.Name) < 1
-	})
-
-	header, rows = getDeployResultTable(results)
-	if len(rows) == 0 {
-		return nil
-	}
-
-	DefaultTablePrinter(header, rows, cmd.OutOrStdout())
-	for _, deploy := range results {
-		if !deploy.Success {
-			return errors.New("One or more deploys failed")
+		if _, exists := AO.Clusters[flagCluster]; !exists {
+			return errors.New(fmt.Sprintf("No such cluster %s", flagCluster))
 		}
 	}
 
 	return nil
 }
 
-func filterExcludes(expressions, applications []string) ([]string, error) {
+func getApplications(apiClient client.AuroraConfigClient, search, version string, excludes []string, out io.Writer) ([]string, error) {
+	files, err := apiClient.GetFileNames()
+	if err != nil {
+		return nil, err
+	}
 
+	possibleDeploys := files.GetApplicationIds()
+	applications := fuzzy.SearchForApplications(search, possibleDeploys)
+
+	applications, err = filterExcludes(excludes, applications)
+	if err != nil {
+		return nil, err
+	}
+
+	if version != "" {
+		if len(applications) > 1 {
+			return nil, errors.New("Deploy with version does only support one application")
+		}
+
+		fileName, err := files.Find(applications[0])
+		if err != nil {
+			return nil, err
+		}
+
+		err = updateVersion(apiClient, version, fileName, out)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return applications, nil
+}
+
+func updateVersion(apiClient client.AuroraConfigClient, version, fileName string, out io.Writer) error {
+	path, value := "/version", version
+
+	fileName, err := SetValue(apiClient, fileName, path, value)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "%s has been updated with %s %s\n", fileName, path, value)
+
+	return nil
+}
+
+func getFilteredDeploymentSpecs(apiClient client.DeploySpecClient, applications []string, overrideCluster string) ([]client.DeploySpec, error) {
+	deploySpecs, err := apiClient.GetAuroraDeploySpec(applications, true)
+	if err != nil {
+		return nil, err
+	}
+	var filteredDeploymentSpecs []client.DeploySpec
+	if overrideCluster != "" {
+		for _, spec := range deploySpecs {
+			if spec.Value("/cluster").(string) == overrideCluster {
+				filteredDeploymentSpecs = append(filteredDeploymentSpecs, spec)
+			}
+		}
+	} else {
+		filteredDeploymentSpecs = deploySpecs
+	}
+
+	return filteredDeploymentSpecs, nil
+}
+
+func createDeploymentUnits(affiliation, overrideToken string, clusters map[string]*config.Cluster, deploymentSpecs []client.DeploySpec) map[deploymentUnitID]*deploymentUnit {
+	unitsMap := make(map[deploymentUnitID]*deploymentUnit)
+
+	for _, spec := range deploymentSpecs {
+		appID := spec.Value("applicationId").(string)
+		clusterName := spec.Value("cluster").(string)
+		envName := spec.Value("envName").(string)
+
+		unitID := newDeploymentUnitID(clusterName, envName)
+
+		if _, exists := unitsMap[*unitID]; !exists {
+			cluster := clusters[clusterName]
+			unit := newDeploymentUnit(unitID, []string{}, cluster, affiliation, overrideToken)
+			unitsMap[*unitID] = unit
+		}
+
+		unitsMap[*unitID].applicationList = append(unitsMap[*unitID].applicationList, appID)
+	}
+
+	return unitsMap
+}
+
+func filterExcludes(expressions, applications []string) ([]string, error) {
 	apps := make([]string, len(applications))
 	copy(apps, applications)
 	for _, expr := range expressions {
@@ -251,41 +287,17 @@ func filterExcludes(expressions, applications []string) ([]string, error) {
 	return apps, nil
 }
 
-func deployToReachableClusters(affiliation, token string, clusters map[string]*config.Cluster, payload *client.DeployPayload) ([]*client.DeployResults, error) {
-
-	reachableClusters := 0
+func deployToReachableClusters(getClient func(unit *deploymentUnit) client.DeployClient, deploymentUnits map[deploymentUnitID]*deploymentUnit, overrideConfig map[string]string) ([]*client.DeployResults, error) {
 	deployResult := make(chan *client.DeployResults)
 	deployErrors := make(chan error)
-	for _, c := range clusters {
-		if !c.Reachable {
-			continue
-		}
-		reachableClusters++
 
-		clusterToken := c.Token
-		if token != "" {
-			clusterToken = token
-		}
-
-		cli := &client.ApiClient{
-			Affiliation: affiliation,
-			Host:        c.BooberUrl,
-			Token:       clusterToken,
-			RefName:     DefaultApiClient.RefName,
-		}
-
-		go func() {
-			result, err := cli.Deploy(payload)
-			if err != nil {
-				deployErrors <- err
-			} else {
-				deployResult <- result
-			}
-		}()
+	for _, unit := range deploymentUnits {
+		deployClient := getClient(unit)
+		go deployUnit(deployClient, unit, overrideConfig, deployResult, deployErrors)
 	}
 
 	var allResults []*client.DeployResults
-	for i := 0; i < reachableClusters; i++ {
+	for i := 0; i < len(deploymentUnits); i++ {
 		select {
 		case err := <-deployErrors:
 			return nil, err
@@ -297,12 +309,26 @@ func deployToReachableClusters(affiliation, token string, clusters map[string]*c
 	return allResults, nil
 }
 
-func parseOverride(override []string) (map[string]string, error) {
+func deployUnit(deployClient client.DeployClient, unit *deploymentUnit, overrideConfig map[string]string, deployResult chan<- *client.DeployResults, deployErrors chan<- error) {
+	if !unit.cluster.Reachable {
+		return // TODO
+	}
+	payload := client.NewDeployPayload(unit.applicationList, overrideConfig)
+
+	result, err := deployClient.Deploy(payload)
+	if err != nil {
+		deployErrors <- err
+	} else {
+		deployResult <- result
+	}
+}
+
+func parseOverride() (map[string]string, error) {
 	returnMap := make(map[string]string)
-	for i := 0; i < len(override); i++ {
-		indexByte := strings.IndexByte(override[i], ':')
-		filename := override[i][:indexByte]
-		jsonOverride := override[i][indexByte+1:]
+	for i := 0; i < len(flagOverrides); i++ {
+		indexByte := strings.IndexByte(flagOverrides[i], ':')
+		filename := flagOverrides[i][:indexByte]
+		jsonOverride := flagOverrides[i][indexByte+1:]
 
 		if !json.Valid([]byte(jsonOverride)) {
 			msg := fmt.Sprintf("%s is not a valid json", jsonOverride)
@@ -312,6 +338,55 @@ func parseOverride(override []string) (map[string]string, error) {
 		returnMap[filename] = jsonOverride
 	}
 	return returnMap, nil
+}
+
+func userConfirmation(filteredDeploymentSpecs []client.DeploySpec, out io.Writer) bool {
+	header, rows := GetDeploySpecTable(filteredDeploymentSpecs)
+	DefaultTablePrinter(header, rows, out)
+
+	var filteredApplications []string
+	for _, spec := range filteredDeploymentSpecs {
+		appID := spec.Value("applicationId").(string)
+		filteredApplications = append(filteredApplications, appID)
+	}
+
+	shouldDeploy := true
+	if !flagNoPrompt {
+		defaultAnswer := len(filteredApplications) == 1
+		message := fmt.Sprintf("Do you want to deploy %d application(s)?", len(filteredApplications))
+		shouldDeploy = prompt.Confirm(message, defaultAnswer)
+	}
+
+	return shouldDeploy
+}
+
+func printDeployResult(result []*client.DeployResults, out io.Writer) error {
+	var results []client.DeployResult
+	for _, r := range result {
+		results = append(results, r.Results...)
+	}
+
+	if len(results) == 0 {
+		return errors.New("No deploys were made")
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return strings.Compare(results[i].ADS.Name, results[j].ADS.Name) < 1
+	})
+
+	header, rows := getDeployResultTable(results)
+	if len(rows) == 0 {
+		return nil
+	}
+
+	DefaultTablePrinter(header, rows, out)
+	for _, deploy := range results {
+		if !deploy.Success {
+			return errors.New("One or more deploys failed")
+		}
+	}
+
+	return nil
 }
 
 func getDeployResultTable(deploys []client.DeployResult) (string, []string) {
@@ -332,4 +407,40 @@ func getDeployResultTable(deploys []client.DeployResult) (string, []string) {
 
 	header := "\x1b[00mSTATUS\x1b[0m\tCLUSTER\tENVIRONMENT\tAPPLICATION\tVERSION\tDEPLOY_ID\tMESSAGE"
 	return header, rows
+}
+
+func getAPIClient(affiliation, overrideToken, overrideCluster string) (*client.ApiClient, error) {
+	api := DefaultApiClient
+	api.Affiliation = affiliation
+
+	if overrideCluster != "" && !AO.Localhost {
+		c := AO.Clusters[overrideCluster]
+		if !c.Reachable {
+			return nil, errors.Errorf("%s cluster is not reachable", overrideCluster)
+		}
+
+		api.Host = c.BooberUrl
+		api.Token = c.Token
+		if overrideToken != "" {
+			api.Token = overrideToken
+		}
+	}
+
+	return api, nil
+}
+
+func getDeployClient(unit *deploymentUnit) client.DeployClient {
+	var updateClient *client.ApiClient
+	if AO.Localhost {
+		updateClient = DefaultApiClient
+		updateClient.Affiliation = unit.affiliation
+	} else {
+		token := unit.cluster.Token
+		if unit.overrideToken != "" {
+			token = unit.overrideToken
+		}
+		updateClient = client.NewApiClient(unit.cluster.BooberUrl, token, unit.affiliation)
+	}
+
+	return updateClient
 }

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -1,0 +1,274 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/skatteetaten/ao/pkg/client"
+	"github.com/skatteetaten/ao/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockDeploySpec map[string]interface{}
+
+type APIClientMock struct {
+	mock.Mock
+}
+
+type AurorConfigClientMock struct {
+	APIClientMock
+	files []string
+}
+
+type DeploySpecClientMock struct {
+	APIClientMock
+	deploySpecs []client.DeploySpec
+}
+
+type DeployClientMock struct {
+	APIClientMock
+}
+
+var applicationNames = [...]string{
+	"dev/crm", "dev/erp", "dev/sap",
+	"test-qa/crm", "test-qa/crmv2", "test-qa/booking", "test-qa/erp",
+	"test-st/crm-1-GA", "test-st/crm-2-GA", "test-st/booking", "test-st/erp",
+	"prod/crm", "prod/booking",
+}
+
+var fileNames = [...]string{
+	"dev/crm.json", "dev/erp.json", "dev/sap.json", "dev/about.json",
+	"test-qa/crm.json", "test-qa/crmv2.json", "test-qa/booking.json", "test-qa/erp.json", "test-qa/about.json",
+	"test-st/crm-1-GA.json", "test-st/crm-2-GA.json", "test-st/booking.json", "test-st/erp.json", "test-st/about.json",
+	"prod/crm.json", "prod/booking.json", "prod/about.json",
+}
+
+var testSpecs = [...]client.DeploySpec{
+	&MockDeploySpec{"applicationId": "dev/crm", "cluster": "east", "envName": "dev"},
+	&MockDeploySpec{"applicationId": "dev/erp", "cluster": "east", "envName": "dev"},
+	&MockDeploySpec{"applicationId": "dev/sap", "cluster": "east", "envName": "dev"},
+	&MockDeploySpec{"applicationId": "test-qa/crm", "cluster": "west", "envName": "test-qa"},
+	&MockDeploySpec{"applicationId": "test-qa/crmv2", "cluster": "west", "envName": "test-qa"},
+	&MockDeploySpec{"applicationId": "test-qa/booking", "cluster": "west", "envName": "test-qa"},
+	&MockDeploySpec{"applicationId": "test-qa/erp", "cluster": "west", "envName": "test-qa"},
+	&MockDeploySpec{"applicationId": "test-st/crm-1-GA", "cluster": "west", "envName": "test-st"},
+	&MockDeploySpec{"applicationId": "test-st/crm-2-GA", "cluster": "west", "envName": "test-st"},
+	&MockDeploySpec{"applicationId": "test-st/booking", "cluster": "west", "envName": "test-st"},
+	&MockDeploySpec{"applicationId": "test-st/erp", "cluster": "west", "envName": "test-st"},
+	&MockDeploySpec{"applicationId": "prod/crm", "cluster": "north", "envName": "prod"},
+	&MockDeploySpec{"applicationId": "prod/booking", "cluster": "north", "envName": "prod"},
+}
+
+var testClusters = map[string]*config.Cluster{
+	"east":  newTestCluster("east", true),
+	"west":  newTestCluster("west", true),
+	"north": newTestCluster("north", true),
+}
+
+func newAuroraConfigClientMock() *AurorConfigClientMock {
+	return &AurorConfigClientMock{files: fileNames[:]}
+}
+
+func newDeploySpecClientMock() *DeploySpecClientMock {
+	return &DeploySpecClientMock{deploySpecs: testSpecs[:]}
+}
+
+func newDeployClientMock() *DeployClientMock {
+	return &DeployClientMock{}
+}
+
+func newTestCluster(name string, reachable bool) *config.Cluster {
+	return &config.Cluster{
+		Name:      name,
+		Url:       name + ".url",
+		Token:     name + ".token",
+		Reachable: reachable,
+		BooberUrl: name + "boober.url",
+	}
+}
+
+func (api *APIClientMock) Do(method string, endpoint string, payload []byte) (*client.BooberResponse, error) {
+	return nil, nil
+}
+
+func (api *APIClientMock) DoWithHeader(method string, endpoint string, header map[string]string, payload []byte) (*client.ResponseBundle, error) {
+	return nil, nil
+}
+
+func (api *DeploySpecClientMock) GetAuroraDeploySpec(applications []string, defaults bool) ([]client.DeploySpec, error) {
+	return api.deploySpecs, nil
+}
+
+func (api *DeploySpecClientMock) GetAuroraDeploySpecFormatted(environment, application string, defaults bool) (string, error) {
+	return "", nil
+}
+
+func (api *AurorConfigClientMock) GetFileNames() (client.FileNames, error) {
+	return api.files, nil
+}
+
+func (api *AurorConfigClientMock) GetAuroraConfig() (*client.AuroraConfig, error) {
+	return nil, nil
+}
+
+func (api *AurorConfigClientMock) GetAuroraConfigNames() (*client.AuroraConfigNames, error) {
+	return nil, nil
+}
+
+func (api *AurorConfigClientMock) PutAuroraConfig(endpoint string, ac *client.AuroraConfig) error {
+	return nil
+}
+
+func (api *AurorConfigClientMock) ValidateAuroraConfig(ac *client.AuroraConfig, fullValidation bool) error {
+	return nil
+}
+
+func (api *AurorConfigClientMock) PatchAuroraConfigFile(fileName string, operation client.JsonPatchOp) error {
+	return nil
+}
+
+func (api *AurorConfigClientMock) GetAuroraConfigFile(fileName string) (*client.AuroraConfigFile, string, error) {
+	return nil, "nil", nil
+}
+
+func (api *AurorConfigClientMock) PutAuroraConfigFile(file *client.AuroraConfigFile, eTag string) error {
+	return nil
+}
+
+func (api *DeployClientMock) Deploy(deployPayload *client.DeployPayload) (*client.DeployResults, error) {
+	api.Called()
+	return &client.DeployResults{Message: "Successful", Success: true, Results: []client.DeployResult{}}, nil
+}
+
+func (api *DeployClientMock) GetApplyResult(deployId string) (string, error) {
+	return "", nil
+}
+
+func (mds MockDeploySpec) Value(jsonPointer string) interface{} {
+	key := strings.Replace(jsonPointer, "/", "", -1)
+	return mds[key]
+}
+
+func Test_getApplications(t *testing.T) {
+	search := "test/crm"
+
+	apiClient := newAuroraConfigClientMock()
+
+	actualApplications, err := getApplications(apiClient, search, "", []string{}, os.Stdout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Len(t, actualApplications, 4)
+	assert.Contains(t, actualApplications, "test-qa/crm")
+	assert.Contains(t, actualApplications, "test-qa/crmv2")
+	assert.Contains(t, actualApplications, "test-st/crm-1-GA")
+	assert.Contains(t, actualApplications, "test-st/crm-2-GA")
+}
+
+func Test_getApplicationsWithExclusions(t *testing.T) {
+	search := "test/crm"
+	exclusions := []string{"test-qa/crmv2", "test-st/crm-1-GA"}
+
+	apiClient := newAuroraConfigClientMock()
+
+	actualApplications, err := getApplications(apiClient, search, "", exclusions, os.Stdout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Len(t, actualApplications, 2)
+	assert.Contains(t, actualApplications, "test-qa/crm")
+	assert.Contains(t, actualApplications, "test-st/crm-2-GA")
+}
+
+func Test_getFilteredDeploymentSpecs(t *testing.T) {
+	apiClient := newDeploySpecClientMock()
+
+	filteredSpecs, err := getFilteredDeploymentSpecs(apiClient, applicationNames[:], "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Len(t, filteredSpecs, 13)
+}
+
+func Test_getFilteredDeploymentSpecsWithOverrideCluster(t *testing.T) {
+	apiClient := newDeploySpecClientMock()
+
+	filteredSpecs, err := getFilteredDeploymentSpecs(apiClient, applicationNames[:], "east")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Len(t, filteredSpecs, 3)
+}
+
+func Test_createDeploymentUnits(t *testing.T) {
+
+	affiliation := "sales"
+	overrideToken := ""
+
+	units := createDeploymentUnits(affiliation, overrideToken, testClusters, testSpecs[:])
+
+	assert.Len(t, units, 4)
+	assert.Contains(t, units, *newDeploymentUnitID("east", "dev"))
+	assert.Contains(t, units, *newDeploymentUnitID("west", "test-st"))
+	assert.Contains(t, units, *newDeploymentUnitID("west", "test-qa"))
+	assert.Contains(t, units, *newDeploymentUnitID("north", "prod"))
+
+	sampleUnit := units[*newDeploymentUnitID("west", "test-st")]
+
+	assert.Equal(t, affiliation, sampleUnit.affiliation)
+	assert.Equal(t, "west", sampleUnit.cluster.Name)
+	assert.Equal(t, overrideToken, sampleUnit.overrideToken)
+	assert.Len(t, sampleUnit.applicationList, 4)
+	assert.Contains(t, sampleUnit.applicationList, "test-st/crm-1-GA")
+	assert.Contains(t, sampleUnit.applicationList, "test-st/crm-2-GA")
+	assert.Contains(t, sampleUnit.applicationList, "test-st/booking")
+	assert.Contains(t, sampleUnit.applicationList, "test-st/erp")
+}
+
+func Test_createDeploymentUnitsWithOverrideToken(t *testing.T) {
+	affiliation := "east"
+	overrideToken := "footoken"
+
+	units := createDeploymentUnits(affiliation, overrideToken, testClusters, testSpecs[:])
+
+	sampleUnit := units[*newDeploymentUnitID("west", "test-st")]
+
+	assert.Equal(t, overrideToken, sampleUnit.overrideToken)
+}
+
+func Test_deployToReachableClusters(t *testing.T) {
+	affiliation := "sales"
+	overrideToken := ""
+
+	deployClientMock := newDeployClientMock()
+
+	getClient := func(unit *deploymentUnit) client.DeployClient {
+		return deployClientMock
+	}
+
+	deploymentUnits := map[deploymentUnitID]*deploymentUnit{
+		*newDeploymentUnitID("east", "dev"): newDeploymentUnit(newDeploymentUnitID("east", "dev"),
+			[]string{"dev/crm", "dev/erp", "dev/sap"}, newTestCluster("east", true), affiliation, overrideToken),
+		*newDeploymentUnitID("west", "test-qa"): newDeploymentUnit(newDeploymentUnitID("west", "test"),
+			[]string{"test-qa/crm", "test-qa/crmv2", "test-qa/booking", "test-qa/erp"}, newTestCluster("west", true), affiliation, overrideToken),
+		*newDeploymentUnitID("west", "test-st"): newDeploymentUnit(newDeploymentUnitID("west", "test"),
+			[]string{"test-st/crm-1-GA", "test-st/crm-2-GA", "test-st/booking", "test-st/erp"}, newTestCluster("west", true), affiliation, overrideToken),
+		*newDeploymentUnitID("north", "prod"): newDeploymentUnit(newDeploymentUnitID("north", "prod"),
+			[]string{"prod/crm", "prod/booking"}, newTestCluster("north", true), affiliation, overrideToken),
+	}
+
+	deployClientMock.On("Deploy", mock.Anything).Times(4)
+
+	_, err := deployToReachableClusters(getClient, deploymentUnits, map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deployClientMock.AssertExpectations(t)
+}

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/skatteetaten/ao/pkg/client"
 	"github.com/skatteetaten/ao/pkg/config"
 	"github.com/stretchr/testify/assert"
@@ -46,19 +47,19 @@ var fileNames = [...]string{
 }
 
 var testSpecs = [...]client.DeploySpec{
-	&MockDeploySpec{"applicationId": "dev/crm", "cluster": "east", "envName": "dev"},
-	&MockDeploySpec{"applicationId": "dev/erp", "cluster": "east", "envName": "dev"},
-	&MockDeploySpec{"applicationId": "dev/sap", "cluster": "east", "envName": "dev"},
-	&MockDeploySpec{"applicationId": "test-qa/crm", "cluster": "west", "envName": "test-qa"},
-	&MockDeploySpec{"applicationId": "test-qa/crmv2", "cluster": "west", "envName": "test-qa"},
-	&MockDeploySpec{"applicationId": "test-qa/booking", "cluster": "west", "envName": "test-qa"},
-	&MockDeploySpec{"applicationId": "test-qa/erp", "cluster": "west", "envName": "test-qa"},
-	&MockDeploySpec{"applicationId": "test-st/crm-1-GA", "cluster": "west", "envName": "test-st"},
-	&MockDeploySpec{"applicationId": "test-st/crm-2-GA", "cluster": "west", "envName": "test-st"},
-	&MockDeploySpec{"applicationId": "test-st/booking", "cluster": "west", "envName": "test-st"},
-	&MockDeploySpec{"applicationId": "test-st/erp", "cluster": "west", "envName": "test-st"},
-	&MockDeploySpec{"applicationId": "prod/crm", "cluster": "north", "envName": "prod"},
-	&MockDeploySpec{"applicationId": "prod/booking", "cluster": "north", "envName": "prod"},
+	&MockDeploySpec{"applicationId": "dev/crm", "cluster": "east", "envName": "dev", "affiliation": "sales"},
+	&MockDeploySpec{"applicationId": "dev/erp", "cluster": "east", "envName": "dev", "affiliation": "sales"},
+	&MockDeploySpec{"applicationId": "dev/sap", "cluster": "east", "envName": "dev", "affiliation": "sales"},
+	&MockDeploySpec{"applicationId": "test-qa/crm", "cluster": "west", "envName": "test-qa", "affiliation": "sales"},
+	&MockDeploySpec{"applicationId": "test-qa/crmv2", "cluster": "west", "envName": "test-qa", "affiliation": "sales"},
+	&MockDeploySpec{"applicationId": "test-qa/booking", "cluster": "west", "envName": "test-qa", "affiliation": "sales"},
+	&MockDeploySpec{"applicationId": "test-qa/erp", "cluster": "west", "envName": "test-qa", "affiliation": "sales"},
+	&MockDeploySpec{"applicationId": "test-st/crm-1-GA", "cluster": "west", "envName": "test-st", "affiliation": "sales"},
+	&MockDeploySpec{"applicationId": "test-st/crm-2-GA", "cluster": "west", "envName": "test-st", "affiliation": "sales"},
+	&MockDeploySpec{"applicationId": "test-st/booking", "cluster": "west", "envName": "test-st", "affiliation": "sales"},
+	&MockDeploySpec{"applicationId": "test-st/erp", "cluster": "west", "envName": "test-st", "affiliation": "sales"},
+	&MockDeploySpec{"applicationId": "prod/crm", "cluster": "north", "envName": "prod", "affiliation": "sales"},
+	&MockDeploySpec{"applicationId": "prod/booking", "cluster": "north", "envName": "prod", "affiliation": "sales"},
 }
 
 var testClusters = map[string]*config.Cluster{
@@ -110,31 +111,31 @@ func (api *AurorConfigClientMock) GetFileNames() (client.FileNames, error) {
 }
 
 func (api *AurorConfigClientMock) GetAuroraConfig() (*client.AuroraConfig, error) {
-	return nil, nil
+	return nil, errors.New("Not implemented")
 }
 
 func (api *AurorConfigClientMock) GetAuroraConfigNames() (*client.AuroraConfigNames, error) {
-	return nil, nil
+	return nil, errors.New("Not implemented")
 }
 
 func (api *AurorConfigClientMock) PutAuroraConfig(endpoint string, ac *client.AuroraConfig) error {
-	return nil
+	return errors.New("Not implemented")
 }
 
 func (api *AurorConfigClientMock) ValidateAuroraConfig(ac *client.AuroraConfig, fullValidation bool) error {
-	return nil
+	return errors.New("Not implemented")
 }
 
 func (api *AurorConfigClientMock) PatchAuroraConfigFile(fileName string, operation client.JsonPatchOp) error {
-	return nil
+	return errors.New("Not implemented")
 }
 
 func (api *AurorConfigClientMock) GetAuroraConfigFile(fileName string) (*client.AuroraConfigFile, string, error) {
-	return nil, "nil", nil
+	return nil, "", errors.New("Not implemented")
 }
 
 func (api *AurorConfigClientMock) PutAuroraConfigFile(file *client.AuroraConfigFile, eTag string) error {
-	return nil
+	return errors.New("Not implemented")
 }
 
 func (api *DeployClientMock) Deploy(deployPayload *client.DeployPayload) (*client.DeployResults, error) {
@@ -143,7 +144,7 @@ func (api *DeployClientMock) Deploy(deployPayload *client.DeployPayload) (*clien
 }
 
 func (api *DeployClientMock) GetApplyResult(deployId string) (string, error) {
-	return "", nil
+	return "", errors.New("Not implemented")
 }
 
 func (mds MockDeploySpec) Value(jsonPointer string) interface{} {
@@ -208,10 +209,10 @@ func Test_getFilteredDeploymentSpecsWithOverrideCluster(t *testing.T) {
 
 func Test_createDeploymentUnits(t *testing.T) {
 
-	affiliation := "sales"
+	auroraConfig := "jupiter"
 	overrideToken := ""
 
-	units := createDeploymentUnits(affiliation, overrideToken, testClusters, testSpecs[:])
+	units := createDeploymentUnits(auroraConfig, overrideToken, testClusters, testSpecs[:])
 
 	assert.Len(t, units, 4)
 	assert.Contains(t, units, *newDeploymentUnitID("east", "dev"))
@@ -221,21 +222,21 @@ func Test_createDeploymentUnits(t *testing.T) {
 
 	sampleUnit := units[*newDeploymentUnitID("west", "test-st")]
 
-	assert.Equal(t, affiliation, sampleUnit.affiliation)
+	assert.Equal(t, auroraConfig, sampleUnit.auroraConfig)
 	assert.Equal(t, "west", sampleUnit.cluster.Name)
 	assert.Equal(t, overrideToken, sampleUnit.overrideToken)
-	assert.Len(t, sampleUnit.applicationList, 4)
-	assert.Contains(t, sampleUnit.applicationList, "test-st/crm-1-GA")
-	assert.Contains(t, sampleUnit.applicationList, "test-st/crm-2-GA")
-	assert.Contains(t, sampleUnit.applicationList, "test-st/booking")
-	assert.Contains(t, sampleUnit.applicationList, "test-st/erp")
+	assert.Len(t, sampleUnit.deploySpecList, 4)
+	assert.IsType(t, sampleUnit.deploySpecList[0], &MockDeploySpec{})
+	assert.IsType(t, sampleUnit.deploySpecList[1], &MockDeploySpec{})
+	assert.IsType(t, sampleUnit.deploySpecList[2], &MockDeploySpec{})
+	assert.IsType(t, sampleUnit.deploySpecList[3], &MockDeploySpec{})
 }
 
 func Test_createDeploymentUnitsWithOverrideToken(t *testing.T) {
-	affiliation := "east"
+	auroraConfig := "jupiter"
 	overrideToken := "footoken"
 
-	units := createDeploymentUnits(affiliation, overrideToken, testClusters, testSpecs[:])
+	units := createDeploymentUnits(auroraConfig, overrideToken, testClusters, testSpecs[:])
 
 	sampleUnit := units[*newDeploymentUnitID("west", "test-st")]
 
@@ -243,7 +244,7 @@ func Test_createDeploymentUnitsWithOverrideToken(t *testing.T) {
 }
 
 func Test_deployToReachableClusters(t *testing.T) {
-	affiliation := "sales"
+	auroraConfig := "jupiter"
 	overrideToken := ""
 
 	deployClientMock := newDeployClientMock()
@@ -254,13 +255,13 @@ func Test_deployToReachableClusters(t *testing.T) {
 
 	deploymentUnits := map[deploymentUnitID]*deploymentUnit{
 		*newDeploymentUnitID("east", "dev"): newDeploymentUnit(newDeploymentUnitID("east", "dev"),
-			[]string{"dev/crm", "dev/erp", "dev/sap"}, newTestCluster("east", true), affiliation, overrideToken),
+			testSpecs[0:3], newTestCluster("east", true), auroraConfig, overrideToken),
 		*newDeploymentUnitID("west", "test-qa"): newDeploymentUnit(newDeploymentUnitID("west", "test"),
-			[]string{"test-qa/crm", "test-qa/crmv2", "test-qa/booking", "test-qa/erp"}, newTestCluster("west", true), affiliation, overrideToken),
+			testSpecs[3:7], newTestCluster("west", true), auroraConfig, overrideToken),
 		*newDeploymentUnitID("west", "test-st"): newDeploymentUnit(newDeploymentUnitID("west", "test"),
-			[]string{"test-st/crm-1-GA", "test-st/crm-2-GA", "test-st/booking", "test-st/erp"}, newTestCluster("west", true), affiliation, overrideToken),
+			testSpecs[7:11], newTestCluster("west", true), auroraConfig, overrideToken),
 		*newDeploymentUnitID("north", "prod"): newDeploymentUnit(newDeploymentUnitID("north", "prod"),
-			[]string{"prod/crm", "prod/booking"}, newTestCluster("north", true), affiliation, overrideToken),
+			testSpecs[11:13], newTestCluster("north", true), auroraConfig, overrideToken),
 	}
 
 	deployClientMock.On("Deploy", mock.Anything).Times(4)
@@ -271,4 +272,36 @@ func Test_deployToReachableClusters(t *testing.T) {
 	}
 
 	deployClientMock.AssertExpectations(t)
+}
+
+func Test_deployToUnreachableClusters(t *testing.T) {
+	auroraConfig := "jupiter"
+	overrideToken := ""
+
+	deployClientMock := newDeployClientMock()
+
+	getClient := func(unit *deploymentUnit) client.DeployClient {
+		return deployClientMock
+	}
+
+	deploymentUnits := map[deploymentUnitID]*deploymentUnit{
+		*newDeploymentUnitID("east", "dev"): newDeploymentUnit(newDeploymentUnitID("east", "dev"),
+			testSpecs[0:3], newTestCluster("east", false), auroraConfig, overrideToken),
+	}
+
+	results, err := deployToReachableClusters(getClient, deploymentUnits, map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Len(t, results, 1)
+	assert.Len(t, results[0].Results, 3)
+	assert.Equal(t, results[0].Results[0].Success, false)
+	assert.Equal(t, results[0].Results[0].Reason, "Cluster is not reachable")
+
+	assert.Equal(t, results[0].Results[1].Success, false)
+	assert.Equal(t, results[0].Results[1].Reason, "Cluster is not reachable")
+
+	assert.Equal(t, results[0].Results[2].Success, false)
+	assert.Equal(t, results[0].Results[2].Reason, "Cluster is not reachable")
 }

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -212,7 +212,11 @@ func Test_createDeploymentUnits(t *testing.T) {
 	auroraConfig := "jupiter"
 	overrideToken := ""
 
-	units := createDeploymentUnits(auroraConfig, overrideToken, testClusters, testSpecs[:])
+	units, err := createDeploymentUnits(auroraConfig, overrideToken, testClusters, testSpecs[:])
+
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	assert.Len(t, units, 4)
 	assert.Contains(t, units, *newDeploymentUnitID("east", "dev"))
@@ -236,7 +240,11 @@ func Test_createDeploymentUnitsWithOverrideToken(t *testing.T) {
 	auroraConfig := "jupiter"
 	overrideToken := "footoken"
 
-	units := createDeploymentUnits(auroraConfig, overrideToken, testClusters, testSpecs[:])
+	units, err := createDeploymentUnits(auroraConfig, overrideToken, testClusters, testSpecs[:])
+
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	sampleUnit := units[*newDeploymentUnitID("west", "test-st")]
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -152,7 +152,7 @@ func PrintDeploySpecTable(args []string, filter fuzzy.FilterMode, cmd *cobra.Com
 	return nil
 }
 
-func GetDeploySpecTable(specs []client.AuroraDeploySpec) (string, []string) {
+func GetDeploySpecTable(specs []client.DeploySpec) (string, []string) {
 	var rows []string
 	header := "CLUSTER\tENVIRONMENT\tAPPLICATION\tVERSION\tREPLICAS\tTYPE\tDEPLOY STRATEGY"
 	pattern := "%v\t%v\t%v\t%v\t%v\t%v\t%v"

--- a/pkg/client/api.go
+++ b/pkg/client/api.go
@@ -35,12 +35,16 @@ type ApiClient struct {
 	RefName     string
 }
 
-func NewApiClient(host, token, affiliation string) *ApiClient {
+func NewApiClientDefaultRef(host, token, affiliation string) *ApiClient {
+	return NewApiClient(host, token, affiliation, "master")
+}
+
+func NewApiClient(host, token, affiliation, refName string) *ApiClient {
 	return &ApiClient{
 		Host:        host,
 		Token:       token,
 		Affiliation: affiliation,
-		RefName:     "master",
+		RefName:     refName,
 	}
 }
 

--- a/pkg/client/api.go
+++ b/pkg/client/api.go
@@ -18,6 +18,11 @@ const (
 	ErrfTokenHasExpired = "Token has expired for (%s). Please login: ao login <affiliation>"
 )
 
+type Doer interface {
+	Do(method string, endpoint string, payload []byte) (*BooberResponse, error)
+	DoWithHeader(method string, endpoint string, header map[string]string, payload []byte) (*ResponseBundle, error)
+}
+
 type ResponseBundle struct {
 	BooberResponse *BooberResponse
 	HttpResponse   *http.Response

--- a/pkg/client/api_test.go
+++ b/pkg/client/api_test.go
@@ -58,7 +58,7 @@ func TestApiClient_Do(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "test", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "test", affiliation)
 		api.Do(http.MethodGet, "/hello", nil)
 	})
 
@@ -74,7 +74,7 @@ func TestApiClient_Do(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "test", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "test", affiliation)
 		res, err := api.Do(http.MethodGet, "/", nil)
 
 		assert.NoError(t, err)
@@ -86,7 +86,7 @@ func TestApiClient_Do(t *testing.T) {
 	})
 
 	t.Run("Should fail when trying to connect to non existing host", func(t *testing.T) {
-		api := NewApiClient("http://notvalid:8080", "", "")
+		api := NewApiClientDefaultRef("http://notvalid:8080", "", "")
 		_, err := api.Do(http.MethodGet, "/", nil)
 		assert.Error(t, err)
 	})
@@ -114,7 +114,7 @@ func TestApiClient_Do(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "", "")
+		api := NewApiClientDefaultRef(ts.URL, "", "")
 		_, err = api.Do(http.MethodPut, "/", payload)
 		assert.NoError(t, err)
 	})
@@ -142,7 +142,7 @@ func TestApiClient_Do(t *testing.T) {
 			}))
 			testServers = append(testServers, ts)
 
-			api := NewApiClient(ts.URL, "test", affiliation)
+			api := NewApiClientDefaultRef(ts.URL, "test", affiliation)
 			_, err := api.Do(http.MethodGet, test.Path, nil)
 
 			assert.Error(t, err)

--- a/pkg/client/apply_result_test.go
+++ b/pkg/client/apply_result_test.go
@@ -2,10 +2,11 @@ package client
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestApiClient_GetApplyResult(t *testing.T) {
@@ -26,7 +27,7 @@ func TestApiClient_GetApplyResult(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "test", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "test", affiliation)
 		result, err := api.GetApplyResult(deployId)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/client/auroraconfig.go
+++ b/pkg/client/auroraconfig.go
@@ -12,6 +12,18 @@ import (
 	"github.com/skatteetaten/ao/pkg/collections"
 )
 
+type AuroraConfigClient interface {
+	Doer
+	GetFileNames() (FileNames, error)
+	GetAuroraConfig() (*AuroraConfig, error)
+	GetAuroraConfigNames() (*AuroraConfigNames, error)
+	PutAuroraConfig(endpoint string, ac *AuroraConfig) error
+	ValidateAuroraConfig(ac *AuroraConfig, fullValidation bool) error
+	PatchAuroraConfigFile(fileName string, operation JsonPatchOp) error
+	GetAuroraConfigFile(fileName string) (*AuroraConfigFile, string, error)
+	PutAuroraConfigFile(file *AuroraConfigFile, eTag string) error
+}
+
 var (
 	ErrJsonPathPrefix = errors.New("json path must start with /")
 )

--- a/pkg/client/auroraconfig_test.go
+++ b/pkg/client/auroraconfig_test.go
@@ -38,7 +38,7 @@ func TestApi_GetAuroraConfig(t *testing.T) {
 		ts := httptest.NewServer(AuroraConfigSuccessResponseHandler(t, fileName))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "", affiliation)
 		ac, errResponse := api.GetAuroraConfig()
 
 		assert.Empty(t, errResponse)
@@ -53,7 +53,7 @@ func TestApiClient_GetFileNames(t *testing.T) {
 		ts := httptest.NewServer(AuroraConfigSuccessResponseHandler(t, fileName))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "", affiliation)
 		fileNames, err := api.GetFileNames()
 
 		assert.NoError(t, err)
@@ -67,7 +67,7 @@ func TestApiClient_PutAuroraConfig(t *testing.T) {
 		ts := httptest.NewServer(AuroraConfigSuccessResponseHandler(t, fileName))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "", affiliation)
 
 		data := ReadTestFile("auroraconfig_paas_success_validation_request")
 		var ac AuroraConfig
@@ -84,7 +84,7 @@ func TestApiClient_PutAuroraConfig(t *testing.T) {
 		ts := httptest.NewServer(AuroraConfigFailedResponseHandler(t, fileName, http.StatusBadRequest))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "", affiliation)
 		data := ReadTestFile("auroraconfig_paas_fail_validation_request")
 		var ac AuroraConfig
 		err := json.Unmarshal(data, &ac)
@@ -103,7 +103,7 @@ func TestApiClient_GetAuroraConfigFile(t *testing.T) {
 		ts := httptest.NewServer(AuroraConfigSuccessResponseHandler(t, fileName))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "", "paas")
+		api := NewApiClientDefaultRef(ts.URL, "", "paas")
 		// TODO: Test ETag
 		file, _, err := api.GetAuroraConfigFile("about.json")
 		if err != nil {
@@ -123,7 +123,7 @@ func TestApiClient_GetAuroraConfigFile(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "", "")
+		api := NewApiClientDefaultRef(ts.URL, "", "")
 
 		// TODO: Test ETag
 		file, _, err := api.GetAuroraConfigFile("about.json")
@@ -160,7 +160,7 @@ func TestApiClient_PatchAuroraConfigFile(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "", affiliation)
 
 		op := JsonPatchOp{
 			OP:    "add",

--- a/pkg/client/client_config_test.go
+++ b/pkg/client/client_config_test.go
@@ -1,10 +1,11 @@
 package client
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestApiClient_GetClientConfig(t *testing.T) {
@@ -19,7 +20,7 @@ func TestApiClient_GetClientConfig(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "test", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "test", affiliation)
 		clientConfig, err := api.GetClientConfig()
 
 		assert.NoError(t, err)

--- a/pkg/client/deploy.go
+++ b/pkg/client/deploy.go
@@ -8,6 +8,12 @@ import (
 	"strings"
 )
 
+type DeployClient interface {
+	Doer
+	Deploy(deployPayload *DeployPayload) (*DeployResults, error)
+	GetApplyResult(deployId string) (string, error)
+}
+
 type (
 	applicationId struct {
 		Environment string `json:"environment"`

--- a/pkg/client/deploy.go
+++ b/pkg/client/deploy.go
@@ -50,6 +50,14 @@ type (
 	}
 )
 
+func NewApplicationId(name string) *applicationId {
+	slice := strings.Split(name, "/")
+	return &applicationId{
+		Environment: slice[0],
+		Application: slice[1],
+	}
+}
+
 func NewDeployPayload(applications []string, overrides map[string]string) *DeployPayload {
 	applicationIds := createApplicationIds(applications)
 	return &DeployPayload{
@@ -100,11 +108,7 @@ func (api *ApiClient) Deploy(deployPayload *DeployPayload) (*DeployResults, erro
 func createApplicationIds(apps []string) []applicationId {
 	var applicationIds []applicationId
 	for _, app := range apps {
-		envApp := strings.Split(app, "/")
-		applicationIds = append(applicationIds, applicationId{
-			Environment: envApp[0],
-			Application: envApp[1],
-		})
+		applicationIds = append(applicationIds, *NewApplicationId(app))
 	}
 	return applicationIds
 }

--- a/pkg/client/deploy_test.go
+++ b/pkg/client/deploy_test.go
@@ -33,7 +33,7 @@ func TestApiClient_Deploy(t *testing.T) {
 
 		applications := []string{"boober-utv/reference"}
 
-		api := NewApiClient(ts.URL, "test", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "test", affiliation)
 		deployPayload := NewDeployPayload(applications, make(map[string]string))
 		deploys, err := api.Deploy(deployPayload)
 

--- a/pkg/client/deployspec.go
+++ b/pkg/client/deployspec.go
@@ -73,7 +73,8 @@ func (api *ApiClient) GetAuroraDeploySpec(applications []string, defaults bool) 
 		}
 	}
 
-	// TODO !!
+	// Must copy elements to array of interfaces.
+	// TODO: Find a way to avoid having to do this.
 	deploySpecs := make([]DeploySpec, len(allSpecs))
 	for i, spec := range allSpecs {
 		deploySpecs[i] = DeploySpec(spec)

--- a/pkg/client/deployspec.go
+++ b/pkg/client/deployspec.go
@@ -7,6 +7,16 @@ import (
 	"strings"
 )
 
+type DeploySpecClient interface {
+	Doer
+	GetAuroraDeploySpec(applications []string, defaults bool) ([]DeploySpec, error)
+	GetAuroraDeploySpecFormatted(environment, application string, defaults bool) (string, error)
+}
+
+type DeploySpec interface {
+	Value(jsonPointer string) interface{}
+}
+
 type AuroraDeploySpec map[string]interface{}
 
 func (a AuroraDeploySpec) Value(jsonPointer string) interface{} {
@@ -29,7 +39,7 @@ func (a AuroraDeploySpec) get(jsonPointer string) interface{} {
 	return "-"
 }
 
-func (api *ApiClient) GetAuroraDeploySpec(applications []string, defaults bool) ([]AuroraDeploySpec, error) {
+func (api *ApiClient) GetAuroraDeploySpec(applications []string, defaults bool) ([]DeploySpec, error) {
 	endpoint := fmt.Sprintf("/auroradeployspec/%s/?", api.Affiliation)
 	queries := buildDeploySpecQueries(applications, defaults)
 
@@ -63,7 +73,13 @@ func (api *ApiClient) GetAuroraDeploySpec(applications []string, defaults bool) 
 		}
 	}
 
-	return allSpecs, nil
+	// TODO !!
+	deploySpecs := make([]DeploySpec, len(allSpecs))
+	for i, spec := range allSpecs {
+		deploySpecs[i] = DeploySpec(spec)
+	}
+
+	return deploySpecs, nil
 }
 
 func buildDeploySpecQueries(applications []string, defaults bool) []string {

--- a/pkg/client/deployspec_test.go
+++ b/pkg/client/deployspec_test.go
@@ -23,7 +23,7 @@ func TestApiClient_GetAuroraDeploySpec(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "test", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "test", affiliation)
 		spec, err := api.GetAuroraDeploySpec([]string{"aotest/redis"}, true)
 		assert.NoError(t, err)
 
@@ -47,7 +47,7 @@ func TestApiClient_GetAuroraDeploySpecFormatted(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "test", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "test", affiliation)
 		spec, err := api.GetAuroraDeploySpecFormatted("aotest", "redis", true)
 		assert.NoError(t, err)
 

--- a/pkg/client/vault_test.go
+++ b/pkg/client/vault_test.go
@@ -20,7 +20,7 @@ func TestApiClient_GetVaults(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "test", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "test", affiliation)
 		vaults, err := api.GetVaults()
 		assert.NoError(t, err)
 
@@ -40,7 +40,7 @@ func TestApiClient_GetVault(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "test", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "test", affiliation)
 		vault, err := api.GetVault("console")
 		assert.NoError(t, err)
 
@@ -59,7 +59,7 @@ func TestApiClient_DeleteVault(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "test", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "test", affiliation)
 		err := api.DeleteVault("console")
 		assert.NoError(t, err)
 	})
@@ -77,7 +77,7 @@ func TestApiClient_SaveVault(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "test", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "test", affiliation)
 		err := api.SaveVault(*vault)
 		assert.NoError(t, err)
 	})
@@ -93,7 +93,7 @@ func TestApiClient_UpdateSecretFile(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		api := NewApiClient(ts.URL, "test", affiliation)
+		api := NewApiClientDefaultRef(ts.URL, "test", affiliation)
 		err := api.UpdateSecretFile("console", "latest.properties", "", []byte("Rk9PPVRFU1QK"))
 		assert.NoError(t, err)
 	})


### PR DESCRIPTION
PR for AOS-3030. 

* Split cmd.deploy into smaller methods.
* Divided deployment into smaller units (one unit per cluster and env) that are deployed in parallel.
* User gets individual status for each application.
* Added unit tests.
* Created mocks for clients and deployment spec.

Remaining work: 

* Error handling.