### PR TITLE
Feature/4058 legge til fil via gobo

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,11 +1,6 @@
 package cmd
 
 import (
-	"io/ioutil"
-	"os"
-
-	"github.com/pkg/errors"
-	"github.com/skatteetaten/ao/pkg/auroraconfig"
 	"github.com/spf13/cobra"
 )
 
@@ -31,42 +26,9 @@ var addCmd = &cobra.Command{
 	Short:       "Add a single file to the current AuroraConfig",
 	Annotations: map[string]string{"type": "remote"},
 	Example:     addExample,
-	RunE:        Add,
+	RunE:        AddGraphql,
 }
 
 func init() {
 	RootCmd.AddCommand(addCmd)
-}
-
-func Add(cmd *cobra.Command, args []string) error {
-	if len(args) != 2 {
-		return cmd.Usage()
-	}
-
-	fileName, filePath := args[0], args[1]
-	file, err := os.Stat(filePath)
-	if err != nil {
-		return err
-	}
-
-	if file.IsDir() {
-		return errors.New("Only files are supported")
-	}
-
-	data, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		return err
-	}
-
-	err = DefaultApiClient.PutAuroraConfigFile(&auroraconfig.AuroraConfigFile{
-		Name:     fileName,
-		Contents: string(data),
-	}, "")
-	if err != nil {
-		return err
-	}
-
-	cmd.Printf("%s has been added\n", fileName)
-
-	return nil
 }

--- a/cmd/add_graphql.go
+++ b/cmd/add_graphql.go
@@ -29,7 +29,7 @@ func AddGraphql(cmd *cobra.Command, args []string) error {
 }`
 	type ConfigFileValidationResponse struct {
 		message string
-		success string
+		success bool
 	}
 
 	createAuroraConfigFileRequest := graphql.NewRequest(createAuroraConfigFileRequestString)
@@ -42,7 +42,9 @@ func AddGraphql(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// TODO: handle configFileValidationResponse
+	if !configFileValidationResponse.success {
+		return errors.Errorf("Remote error: %s\n", configFileValidationResponse.message)
+	}
 
 	cmd.Printf("%s has been added\n", fileName)
 

--- a/cmd/add_graphql.go
+++ b/cmd/add_graphql.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"github.com/machinebox/graphql"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+	"os"
+)
+
+func AddGraphql(cmd *cobra.Command, args []string) error {
+
+	if len(args) != 2 {
+		return cmd.Usage()
+	}
+
+	fileName, filePath := args[0], args[1]
+	data, err := loadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	createAuroraConfigFileRequestString := `mutation ($auroraConfigName: String!, $fileName: String!, $contents: String!){
+  createAuroraConfigFile(input: {auroraConfigName: $auroraConfigName, fileName: $fileName, contents: $contents })
+  {
+    message
+    success
+  }
+}`
+	type ConfigFileValidationResponse struct {
+		message string
+		success string
+	}
+
+	createAuroraConfigFileRequest := graphql.NewRequest(createAuroraConfigFileRequestString)
+	createAuroraConfigFileRequest.Var("auroraConfigName", DefaultApiClient.Affiliation)
+	createAuroraConfigFileRequest.Var("fileName", fileName)
+	createAuroraConfigFileRequest.Var("contents", string(data))
+
+	var configFileValidationResponse ConfigFileValidationResponse
+	if err := DefaultApiClient.RunGraphQlMutation(createAuroraConfigFileRequest, &configFileValidationResponse); err != nil {
+		return err
+	}
+
+	// TODO: handle configFileValidationResponse
+
+	cmd.Printf("%s has been added\n", fileName)
+
+	return nil
+}
+
+func loadFile(filePath string) ([]byte, error) {
+	file, err := os.Stat(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if file.IsDir() {
+		return nil, errors.New("Only files are supported")
+	}
+
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/pkg/client/goboapi.go
+++ b/pkg/client/goboapi.go
@@ -17,6 +17,18 @@ func (api *ApiClient) RunGraphQl(graphQlRequest string, response interface{}) er
 	return nil
 }
 
+func (api *ApiClient) RunGraphQlMutation(graphQlRequest *graphql.Request, response interface{}) error {
+	client := api.getGraphQlClient()
+	ctx := context.Background()
+	graphQlRequest.Header.Set("Cache-Control", "no-cache")
+	graphQlRequest.Header.Add("Authorization", "Bearer "+api.Token)
+
+	if err := client.Run(ctx, graphQlRequest, response); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (api *ApiClient) getGraphQlClient() *graphql.Client {
 	endpoint := fmt.Sprintf("%s/graphql", api.GoboHost)
 	client := graphql.NewClient(endpoint)

--- a/pkg/client/goboapi.go
+++ b/pkg/client/goboapi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/machinebox/graphql"
+	"github.com/sirupsen/logrus"
 )
 
 func (api *ApiClient) RunGraphQl(graphQlRequest string, response interface{}) error {
@@ -32,6 +33,7 @@ func (api *ApiClient) RunGraphQlMutation(graphQlRequest *graphql.Request, respon
 func (api *ApiClient) getGraphQlClient() *graphql.Client {
 	endpoint := fmt.Sprintf("%s/graphql", api.GoboHost)
 	client := graphql.NewClient(endpoint)
+	client.Log = func(logEntry string) { logrus.Debug(logEntry) }
 	return client
 }
 


### PR DESCRIPTION
Denne leveransen gjelder saken AOS-4058 "Bruke Gobo for å legge til en fil i AuroraConfig".
Når denne er levert, så går kommandoen "ao add" via gobo istedenfor rett på boober.