### PR TITLE
AOS-4460 updating ci-scripts from 2.0.2 to 2.0.4 with dependencies

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -5,13 +5,13 @@
   "requires": true,
   "dependencies": {
     "@skatteetaten/ci-scripts": {
-      "version": "2.0.2",
-      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/@skatteetaten/ci-scripts/-/ci-scripts-2.0.2.tgz",
-      "integrity": "sha512-j2WYcG/uSZ4asQyoOidM4fmHcspeU1qVvk2fd0QQny7UK5/QIh/idaP6ARz0+SMoYlx5NlZIH0r2AHFaaoIXwA==",
+      "version": "2.0.4",
+      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/@skatteetaten/ci-scripts/-/ci-scripts-2.0.4.tgz",
+      "integrity": "sha512-MN6Y+CQQEhWKGc4vGEvJoSLytpaKg62uxE6RllOYDPDBKy5UfRNlUWyYAMbR/yHXjolFXNXreyM8stPIipsgJw==",
       "requires": {
         "aurora-artifact-deployer": "1.0.0",
-        "npm-bundled": "1.0.6",
-        "tar": "5.0.2"
+        "npm-bundled": "1.1.1",
+        "tar": "5.0.5"
       }
     },
     "aurora-artifact-deployer": {
@@ -20,27 +20,27 @@
       "integrity": "sha512-VZlGqEFqjT7toArXzcrybLBjZFZDI/0cpIIa6ZfqhabkY/RpHhlGUD7snSCFvetqPX5LmLvfbj433OGFik0hNA=="
     },
     "chownr": {
-      "version": "1.1.3",
-      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/chownr/-/chownr-1.1.3.tgz",
-      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
+      "version": "1.1.4",
+      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "fs-minipass": {
-      "version": "2.0.0",
-      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/fs-minipass/-/fs-minipass-2.0.0.tgz",
-      "integrity": "sha512-40Qz+LFXmd9tzYVnnBmZvFfvAADfUA14TXPK1s7IfElJTIZ97rA8w4Kin7Wt5JBrC3ShnnFJO/5vPjPEeJIq9A==",
+      "version": "2.1.0",
+      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "requires": {
         "minipass": "^3.0.0"
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.5",
+      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
-      "version": "3.1.1",
-      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/minipass/-/minipass-3.1.1.tgz",
-      "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+      "version": "3.1.3",
+      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -55,27 +55,35 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "npm-bundled": {
-      "version": "1.0.6",
-      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/npm-bundled/-/npm-bundled-1.0.6.tgz",
-      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
+      "version": "1.1.1",
+      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/npm-bundled/-/npm-bundled-1.1.1.tgz",
+      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
     },
     "tar": {
-      "version": "5.0.2",
-      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/tar/-/tar-5.0.2.tgz",
-      "integrity": "sha512-s6QnhHIoyEPImp1Y4Tq3UOhPMT6/4kgHwzeZc9fbgq0/+s6RAzezIT43Meepn5RdUFpxdzQkd5x2PkcFdVIEPw==",
+      "version": "5.0.5",
+      "resolved": "https://nexus-npm.aurora.skead.no/npm/repository/npm-all/tar/-/tar-5.0.5.tgz",
+      "integrity": "sha512-MNIgJddrV2TkuwChwcSNds/5E9VijOiw7kAc1y5hTNJoLDSuIyid2QtLYiCYNnICebpuvjhPQZsXwUL0O3l7OQ==",
       "requires": {
         "chownr": "^1.1.3",
         "fs-minipass": "^2.0.0",
         "minipass": "^3.0.0",
-        "minizlib": "^2.0.0",
+        "minizlib": "^2.1.0",
         "mkdirp": "^0.5.0",
         "yallist": "^4.0.0"
       }

--- a/website/package.json
+++ b/website/package.json
@@ -15,6 +15,6 @@
   ],
   "devDependencies": {},
   "dependencies": {
-    "@skatteetaten/ci-scripts": "^2.0.2"
+    "@skatteetaten/ci-scripts": "^2.0.4"
   }
 }


### PR DESCRIPTION
Updating ci-scripts with all dependencies, inclusive the old minimist version that had a potential security issue.  The snapshot version is built and test deployed.