### PR TITLE
AOS-4608 catching error when check for existing vault

### DIFF
--- a/cmd/vault.go
+++ b/cmd/vault.go
@@ -219,12 +219,11 @@ func RenameVault(cmd *cobra.Command, args []string) error {
 		return cmd.Usage()
 	}
 
-	vault, err := DefaultAPIClient.GetVault(args[1])
-	if vault != nil {
+	if err := verifyVaultDoesNotExist(args[1]); err != nil {
 		return errors.Errorf("Can't rename vault. %s already exists", args[1])
 	}
 
-	vault, err = DefaultAPIClient.GetVault(args[0])
+	vault, err := DefaultAPIClient.GetVault(args[0])
 	if err != nil {
 		return err
 	}
@@ -285,7 +284,7 @@ func CreateVault(cmd *cobra.Command, args []string) error {
 
 func verifyVaultDoesNotExist(vaultname string) error {
 	v, err := DefaultAPIClient.GetVault(vaultname)
-	if err != nil && !strings.Contains(err.Error(), "Vault not found") {
+	if err != nil && err.Error() != client.ErrorVaultNotFound {
 		return errors.Errorf("error when checking vault %s: %v \nmaybe the vault already exists", vaultname, err)
 	}
 	if v != nil {

--- a/cmd/vault.go
+++ b/cmd/vault.go
@@ -251,14 +251,17 @@ func CreateVault(cmd *cobra.Command, args []string) error {
 		return cmd.Usage()
 	}
 
-	v, _ := DefaultAPIClient.GetVault(args[0])
+	v, err := DefaultAPIClient.GetVault(args[0])
+	if err != nil {
+		return errors.Errorf("error when checking vault %s: %v \nmaybe the vault already exists", args[0], err)
+	}
 	if v != nil {
 		return errors.Errorf("vault %s already exists", args[0])
 	}
 
 	vault := client.NewAuroraSecretVault(args[0])
 
-	err := collectSecrets(args[1], vault, true)
+	err = collectSecrets(args[1], vault, true)
 	if err != nil {
 		return err
 	}
@@ -266,6 +269,7 @@ func CreateVault(cmd *cobra.Command, args []string) error {
 	if noPermissionsSpecifiedInCreateVault(args, vault) {
 		return errNoPermissionsSpecified
 	}
+
 	if createVaultHasGroupArguments(args) {
 		logrus.Debugf("Command line permission groups: %v\n", args[2:])
 		vault.Permissions, err = handlePermissionAction(ADD, vault.Permissions, args[2:])

--- a/cmd/vault.go
+++ b/cmd/vault.go
@@ -285,7 +285,7 @@ func CreateVault(cmd *cobra.Command, args []string) error {
 func verifyVaultDoesNotExist(vaultname string) error {
 	v, err := DefaultAPIClient.GetVault(vaultname)
 	if err != nil && err.Error() != client.ErrorVaultNotFound {
-		return errors.Errorf("error when checking vault %s: %v \nmaybe the vault already exists", vaultname, err)
+		return errors.Errorf("error when checking existence of vault %s: %v", vaultname, err)
 	}
 	if v != nil {
 		return errors.Errorf("vault %s already exists", vaultname)

--- a/pkg/client/api.go
+++ b/pkg/client/api.go
@@ -115,6 +115,7 @@ func (api *APIClient) DoWithHeader(method string, endpoint string, header map[st
 	}
 
 	if res.StatusCode > 399 {
+		logrus.Debugf("Got res.StatusCode: %v", res.StatusCode)
 		logrus.WithFields(fields).Error("Request Error")
 	}
 

--- a/pkg/client/api.go
+++ b/pkg/client/api.go
@@ -115,7 +115,6 @@ func (api *APIClient) DoWithHeader(method string, endpoint string, header map[st
 	}
 
 	if res.StatusCode > 399 {
-		logrus.Debugf("Got res.StatusCode: %v", res.StatusCode)
 		logrus.WithFields(fields).Error("Request Error")
 	}
 

--- a/pkg/client/vault.go
+++ b/pkg/client/vault.go
@@ -4,9 +4,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"net/http"
-
 	"github.com/pkg/errors"
+	"net/http"
+	"strings"
 )
 
 type (
@@ -33,6 +33,8 @@ type (
 		Contents string `json:"contents"`
 	}
 )
+
+const ErrorVaultNotFound = "Vault not found"
 
 // NewAuroraSecretVault creates a new AuroraSecretVault
 func NewAuroraSecretVault(name string) *AuroraSecretVault {
@@ -69,6 +71,11 @@ func (api *APIClient) GetVault(vaultName string) (*AuroraSecretVault, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if response != nil && !response.Success && strings.Contains(response.Message, "Vault not found") {
+		return nil, errors.New(ErrorVaultNotFound)
+	}
+
 	var vault AuroraSecretVault
 	err = response.ParseFirstItem(&vault)
 	if err != nil {


### PR DESCRIPTION
Hvis en bruker prøver å lage et nytt vault som har samme navn som et vault som allerede finnes men som han ikke har tilgang til vil AO ignorere dette fordi feil ignoreres - dette er fikset