### PR TITLE
Feature/aos 4441 s rge for at .ao.json blir korrekt for ocp4 clustre

### DIFF
--- a/cmd/adm.go
+++ b/cmd/adm.go
@@ -157,17 +157,31 @@ func RecreateConfig(cmd *cobra.Command, args []string) error {
 	} else if len(flagAddCluster) > 0 {
 		conf.AvailableClusters = append(conf.AvailableClusters, flagAddCluster...)
 	} else if flagBetaMultipleClusterTypes {
-		conf.AvailableClusters = append(conf.AvailableClusters, "utv03")
-		conf.ClusterType = map[string]string{
-			"utv":        "ocp3",
-			"utv-relay":  "ocp3",
-			"test":       "ocp3",
-			"test-relay": "ocp3",
-			"prod":       "ocp3",
-			"prod-relay": "ocp3",
-			"utv03":      "ocp4",
+		conf.AvailableClusters = append(conf.AvailableClusters, "utv03", "ske-l3-aks")
+		conf.ClusterConfig = map[string]*config.ClusterConfig{
+			"utv": {
+				Type: "ocp3",
+			},
+			"utv-relay": {
+				Type: "ocp3",
+			},
+			"test": {
+				Type: "ocp3",
+			},
+			"test-relay": {
+				Type: "ocp3",
+			},
+			"prod": {
+				Type: "ocp3",
+			},
+			"prod-relay": {
+				Type: "ocp3",
+			},
+			"utv03": {
+				Type: "ocp4",
+			}
 		}
-		conf.ClusterURLPatterns = map[string]*config.ServiceURLPatterns{
+		conf.ServiceURLPatterns = map[string]*config.ServiceURLPatterns{
 			"ocp3": {
 				ClusterURLPattern: "https://%s-master.paas.skead.no:8443",
 				BooberURLPattern:  "http://boober-aurora.%s.paas.skead.no",
@@ -175,10 +189,11 @@ func RecreateConfig(cmd *cobra.Command, args []string) error {
 				GoboURLPattern:    "http://gobo.aurora.%s.paas.skead.no",
 			},
 			"ocp4": {
-				ClusterURLPattern: "https://oauth-openshift.apps.%s.paas.skead.no",
-				BooberURLPattern:  "http://boober.aurora.apps.%s.paas.skead.no",
-				UpdateURLPattern:  "http://ao-aurora-tools.%s.paas.skead.no",
-				GoboURLPattern:    "http://gobo.aurora.apps.%s.paas.skead.no",
+				ClusterURLPattern:      "https://api.%s.paas.skead.no:6443",
+				ClusterLoginURLPattern: "https://oauth-openshift.apps.%s.paas.skead.no",
+				BooberURLPattern:       "http://boober.aurora.apps.%s.paas.skead.no",
+				UpdateURLPattern:       "http://ao-aurora-tools.%s.paas.skead.no",
+				GoboURLPattern:         "http://gobo.aurora.apps.%s.paas.skead.no",
 			},
 		}
 	}

--- a/cmd/adm.go
+++ b/cmd/adm.go
@@ -179,7 +179,7 @@ func RecreateConfig(cmd *cobra.Command, args []string) error {
 			},
 			"utv03": {
 				Type: "ocp4",
-			}
+			},
 		}
 		conf.ServiceURLPatterns = map[string]*config.ServiceURLPatterns{
 			"ocp3": {

--- a/cmd/adm.go
+++ b/cmd/adm.go
@@ -156,46 +156,10 @@ func RecreateConfig(cmd *cobra.Command, args []string) error {
 		conf.PreferredAPIClusters = []string{flagCluster}
 	} else if len(flagAddCluster) > 0 {
 		conf.AvailableClusters = append(conf.AvailableClusters, flagAddCluster...)
-	} else if flagBetaMultipleClusterTypes {
-		conf.AvailableClusters = append(conf.AvailableClusters, "utv03", "ske-l3-aks")
-		conf.ClusterConfig = map[string]*config.ClusterConfig{
-			"utv": {
-				Type: "ocp3",
-			},
-			"utv-relay": {
-				Type: "ocp3",
-			},
-			"test": {
-				Type: "ocp3",
-			},
-			"test-relay": {
-				Type: "ocp3",
-			},
-			"prod": {
-				Type: "ocp3",
-			},
-			"prod-relay": {
-				Type: "ocp3",
-			},
-			"utv03": {
-				Type: "ocp4",
-			},
-		}
-		conf.ServiceURLPatterns = map[string]*config.ServiceURLPatterns{
-			"ocp3": {
-				ClusterURLPattern: "https://%s-master.paas.skead.no:8443",
-				BooberURLPattern:  "http://boober-aurora.%s.paas.skead.no",
-				UpdateURLPattern:  "http://ao-aurora-tools.%s.paas.skead.no",
-				GoboURLPattern:    "http://gobo.aurora.%s.paas.skead.no",
-			},
-			"ocp4": {
-				ClusterURLPattern:      "https://api.%s.paas.skead.no:6443",
-				ClusterLoginURLPattern: "https://oauth-openshift.apps.%s.paas.skead.no",
-				BooberURLPattern:       "http://boober.aurora.apps.%s.paas.skead.no",
-				UpdateURLPattern:       "http://ao-aurora-tools.%s.paas.skead.no",
-				GoboURLPattern:         "http://gobo.aurora.apps.%s.paas.skead.no",
-			},
-		}
+	}
+
+	if flagBetaMultipleClusterTypes {
+		conf.AddMultipleClusterConfig()
 	}
 
 	conf.InitClusters()

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -78,7 +78,7 @@ func PreLogin(cmd *cobra.Command, args []string) error {
 		if password == "" {
 			password = prompt.Password()
 		}
-		token, err := config.GetToken(c.URL, flagUserName, password)
+		token, err := config.GetToken(c.LoginURL, flagUserName, password)
 		if err != nil {
 			logrus.WithFields(logrus.Fields{
 				"url":      c.URL,

--- a/pkg/config/ao.go
+++ b/pkg/config/ao.go
@@ -22,6 +22,9 @@ type AOConfig struct {
 	Localhost   bool                `json:"localhost"`
 	Clusters    map[string]*Cluster `json:"clusters"`
 
+	ClusterURLPatterns map[string]*ServiceURLPatterns `json:"clusterURLPatterns"`
+	ClusterType        map[string]string              `json:"clusterType"`
+
 	AvailableClusters       []string `json:"availableClusters"`
 	PreferredAPIClusters    []string `json:"preferredApiClusters"`
 	AvailableUpdateClusters []string `json:"availableUpdateClusters"`
@@ -42,6 +45,24 @@ var DefaultAOConfig = AOConfig{
 	BooberURLPattern:        "http://boober-aurora.%s.paas.skead.no",
 	UpdateURLPattern:        "http://ao-aurora-tools.%s.paas.skead.no",
 	GoboURLPattern:          "http://gobo.aurora.%s.paas.skead.no",
+}
+
+func (ao *AOConfig) GetServiceURLPatterns(clusterName string) (*ServiceURLPatterns, error) {
+	if len(ao.ClusterURLPatterns) == 0 {
+		return &ServiceURLPatterns{
+			BooberURLPattern:  ao.BooberURLPattern,
+			ClusterURLPattern: ao.ClusterURLPattern,
+			UpdateURLPattern:  ao.UpdateURLPattern,
+			GoboURLPattern:    ao.GoboURLPattern,
+		}, nil
+	}
+
+	clusterType := ao.ClusterType[clusterName]
+	if clusterType == "" {
+		return nil, errors.Errorf("Missing cluster type for cluster %s", clusterName)
+	}
+
+	return ao.ClusterURLPatterns[clusterType], nil
 }
 
 // LoadConfigFile loads an AOConfig file from file system

--- a/pkg/config/ao.go
+++ b/pkg/config/ao.go
@@ -15,6 +15,21 @@ import (
 	"github.com/skatteetaten/ao/pkg/prompt"
 )
 
+var ocp3URLPatterns = &ServiceURLPatterns{
+	ClusterURLPattern: "https://%s-master.paas.skead.no:8443",
+	BooberURLPattern:  "http://boober-aurora.%s.paas.skead.no",
+	UpdateURLPattern:  "http://ao-aurora-tools.%s.paas.skead.no",
+	GoboURLPattern:    "http://gobo.aurora.%s.paas.skead.no",
+}
+
+var ocp4URLPatterns = &ServiceURLPatterns{
+	ClusterURLPattern:      "https://api.%s.paas.skead.no:6443",
+	ClusterLoginURLPattern: "https://oauth-openshift.apps.%s.paas.skead.no",
+	BooberURLPattern:       "http://boober.aurora.apps.%s.paas.skead.no",
+	UpdateURLPattern:       "http://ao-aurora-tools.%s.paas.skead.no",
+	GoboURLPattern:         "http://gobo.aurora.apps.%s.paas.skead.no",
+}
+
 // ClusterConfig information about features and configuration for a cluster.
 type ClusterConfig struct {
 	Type             string `json:"type"`
@@ -70,10 +85,10 @@ var DefaultAOConfig = AOConfig{
 	AvailableClusters:       []string{"utv", "utv-relay", "test", "test-relay", "prod", "prod-relay"},
 	PreferredAPIClusters:    []string{"utv", "test"},
 	AvailableUpdateClusters: []string{"utv", "test"},
-	ClusterURLPattern:       "https://%s-master.paas.skead.no:8443",
-	BooberURLPattern:        "http://boober-aurora.%s.paas.skead.no",
-	UpdateURLPattern:        "http://ao-aurora-tools.%s.paas.skead.no",
-	GoboURLPattern:          "http://gobo.aurora.%s.paas.skead.no",
+	ClusterURLPattern:       ocp3URLPatterns.ClusterURLPattern,
+	BooberURLPattern:        ocp3URLPatterns.BooberURLPattern,
+	UpdateURLPattern:        ocp3URLPatterns.UpdateURLPattern,
+	GoboURLPattern:          ocp3URLPatterns.GoboURLPattern,
 }
 
 // GetServiceURLs returns old config if ServiceURLPatterns is empty, else ServiceURLs for a given cluster type
@@ -140,19 +155,8 @@ func (ao *AOConfig) AddMultipleClusterConfig() {
 		},
 	}
 	ao.ServiceURLPatterns = map[string]*ServiceURLPatterns{
-		"ocp3": {
-			ClusterURLPattern: "https://%s-master.paas.skead.no:8443",
-			BooberURLPattern:  "http://boober-aurora.%s.paas.skead.no",
-			UpdateURLPattern:  "http://ao-aurora-tools.%s.paas.skead.no",
-			GoboURLPattern:    "http://gobo.aurora.%s.paas.skead.no",
-		},
-		"ocp4": {
-			ClusterURLPattern:      "https://api.%s.paas.skead.no:6443",
-			ClusterLoginURLPattern: "https://oauth-openshift.apps.%s.paas.skead.no",
-			BooberURLPattern:       "http://boober.aurora.apps.%s.paas.skead.no",
-			UpdateURLPattern:       "http://ao-aurora-tools.%s.paas.skead.no",
-			GoboURLPattern:         "http://gobo.aurora.apps.%s.paas.skead.no",
-		},
+		"ocp3": ocp3URLPatterns,
+		"ocp4": ocp4URLPatterns,
 	}
 }
 

--- a/pkg/config/ao_test.go
+++ b/pkg/config/ao_test.go
@@ -72,6 +72,7 @@ func TestAOConfig_Update(t *testing.T) {
 		ClusterURLPattern:       "%s",
 		UpdateURLPattern:        "%s",
 		BooberURLPattern:        "%s",
+		GoboURLPattern:          "%s",
 		AvailableClusters:       []string{ts.URL},
 		AvailableUpdateClusters: []string{ts.URL},
 	}

--- a/pkg/config/openshift.go
+++ b/pkg/config/openshift.go
@@ -62,9 +62,12 @@ func (ao *AOConfig) InitClusters() {
 			reachable := false
 			resp, err := client.Get(urls.BooberURL)
 			if err == nil && resp != nil && resp.StatusCode < 500 {
-				resp, err = client.Get(urls.ClusterURL)
+				resp, err := client.Get(urls.GoboURL)
 				if err == nil && resp != nil && resp.StatusCode < 500 {
-					reachable = true
+					resp, err = client.Get(urls.ClusterLoginURL)
+					if err == nil && resp != nil && resp.StatusCode < 500 {
+						reachable = true
+					}
 				}
 			}
 

--- a/pkg/config/openshift_test.go
+++ b/pkg/config/openshift_test.go
@@ -92,6 +92,7 @@ func TestAOConfig_InitClusters(t *testing.T) {
 	ao := DefaultAOConfig
 	ao.ClusterURLPattern = "%s"
 	ao.BooberURLPattern = "%s"
+	ao.GoboURLPattern = "%s"
 	ao.AvailableClusters = []string{}
 	ao.PreferredAPIClusters = []string{}
 


### PR DESCRIPTION
Dette er et forslag, kom gjerne med innspill til endringer.

Dette er steg 1 for å støtte flere type clustre med AO, som for.eks OpenShift 4 og Kubernetes. Dette er noe vi trenger for å gjøre det enklere å jobbe med flere typer cluster i høst.

- OpenShift 4 har forskjellig master og login url.
- AKS har et annet url-prefix enn navnet på clusteret.

Vi har lagt til et nytt flagg under adm recreate-config kommandoen; --beta-multiple-cluster-types. Denne legger til ekstra konfigurasjon i .ao.json som er rikere enn dagens konfigurasjon. Vi ønsker på sikt og fjerne availableClusteres, updateClusters og apiClusters med den nye konfigurasjonen.

Denne utgaven beholder den gamle måten å operere på konfigurasjonen, samt støtter ny.