### PR TITLE
Adding info about ao adm recreate config to err in prelogin

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -80,6 +80,7 @@ func PreLogin(cmd *cobra.Command, args []string) error {
 		}
 		token, err := config.GetToken(c.LoginURL, flagUserName, password)
 		if err != nil {
+			indicateAoAdmRecreateConfig(err)
 			logrus.WithFields(logrus.Fields{
 				"url":      c.URL,
 				"userName": flagUserName,


### PR DESCRIPTION
Oppdaget en feil i Aurorarommet som burde vært oppdaget for flagging av bruk av ao adm recreate-config.