### PR TITLE
Feature/aos 4941 ignore errors flag

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-
 	"github.com/skatteetaten/ao/pkg/auroraconfig"
 	"github.com/skatteetaten/ao/pkg/deploymentspec"
 
@@ -241,6 +240,9 @@ func PrintDeploySpec(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+		if flagIgnoreErrors {
+			cmd.Println("NB: The following spec may be incomplete, since the ignore-errors flag was set.")
+		}
 		cmd.Println(spec)
 		return nil
 	}
@@ -255,6 +257,9 @@ func PrintDeploySpec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if flagIgnoreErrors {
+		cmd.Println("NB: The following spec may be incomplete, since the ignore-errors flag was set.")
+	}
 	cmd.Println(string(data))
 	return nil
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -15,9 +15,10 @@ import (
 )
 
 var (
-	flagJSON       bool
-	flagAsList     bool
-	flagNoDefaults bool
+	flagJSON         bool
+	flagAsList       bool
+	flagNoDefaults   bool
+	flagIgnoreErrors bool
 )
 
 var (
@@ -69,9 +70,10 @@ func init() {
 	getCmd.AddCommand(getDeploymentsCmd)
 	getCmd.AddCommand(getSpecCmd)
 
-	getSpecCmd.Flags().BoolVarP(&flagNoDefaults, "no-defaults", "", false, "exclude default values from output")
-	getSpecCmd.Flags().BoolVarP(&flagJSON, "json", "", false, "print deploy spec as json")
-	getDeploymentsCmd.Flags().BoolVarP(&flagAsList, "list", "", false, "print ApplicationDeploymentRefs as a list")
+	getSpecCmd.Flags().BoolVar(&flagNoDefaults, "no-defaults", false, "exclude default values from output")
+	getSpecCmd.Flags().BoolVar(&flagJSON, "json", false, "print deploy spec as json")
+	getSpecCmd.Flags().BoolVar(&flagIgnoreErrors, "ignore-errors", false, "suppresses errors from spec assembly. NB: may return incomplete deploy spec, use with care")
+	getDeploymentsCmd.Flags().BoolVar(&flagAsList, "list", false, "print ApplicationDeploymentRefs as a list")
 }
 
 // PrintAll is the main method for the `get all` cli command
@@ -147,7 +149,7 @@ func PrintDeploySpecTable(args []string, filter auroraconfig.FilterMode, cmd *co
 		}
 		selected = append(selected, matches...)
 	}
-	specs, err := DefaultAPIClient.GetAuroraDeploySpec(selected, true)
+	specs, err := DefaultAPIClient.GetAuroraDeploySpec(selected, true, false)
 	if err != nil {
 		return err
 	}
@@ -235,7 +237,7 @@ func PrintDeploySpec(cmd *cobra.Command, args []string) error {
 	split := strings.Split(matches[0], "/")
 
 	if !flagJSON {
-		spec, err := DefaultAPIClient.GetAuroraDeploySpecFormatted(split[0], split[1], !flagNoDefaults)
+		spec, err := DefaultAPIClient.GetAuroraDeploySpecFormatted(split[0], split[1], !flagNoDefaults, flagIgnoreErrors)
 		if err != nil {
 			return err
 		}
@@ -243,7 +245,7 @@ func PrintDeploySpec(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	spec, err := DefaultAPIClient.GetAuroraDeploySpec(matches, !flagNoDefaults)
+	spec, err := DefaultAPIClient.GetAuroraDeploySpec(matches, !flagNoDefaults, flagIgnoreErrors)
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -92,7 +92,6 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&pFlagNoHeader, "no-headers", false, "Print tables without headers")
 	RootCmd.PersistentFlags().MarkHidden("no-headers")
 	RootCmd.PersistentFlags().StringVar(&pFlagAnswerRecreateConfig, "autoanswer-recreate-config", "", "Set automatic response for ao config question [y, n]")
-	RootCmd.PersistentFlags().MarkHidden("autoanswer-recreate-config")
 }
 
 func initialize(cmd *cobra.Command, args []string) error {

--- a/pkg/client/deployspec_mock.go
+++ b/pkg/client/deployspec_mock.go
@@ -14,11 +14,11 @@ func NewDeploySpecClientMock(deploySpecs []deploymentspec.DeploymentSpec) *Deplo
 }
 
 // GetAuroraDeploySpec default mock implementation
-func (api *DeploySpecClientMock) GetAuroraDeploySpec(applications []string, defaults bool) ([]deploymentspec.DeploymentSpec, error) {
+func (api *DeploySpecClientMock) GetAuroraDeploySpec(applications []string, defaults bool, ignoreErrors bool) ([]deploymentspec.DeploymentSpec, error) {
 	return api.deploySpecs, nil
 }
 
 // GetAuroraDeploySpecFormatted default mock implementation
-func (api *DeploySpecClientMock) GetAuroraDeploySpecFormatted(environment, application string, defaults bool) (string, error) {
+func (api *DeploySpecClientMock) GetAuroraDeploySpecFormatted(environment, application string, defaults bool, ignoreErrors bool) (string, error) {
 	return "", nil
 }

--- a/pkg/client/deployspec_test.go
+++ b/pkg/client/deployspec_test.go
@@ -24,7 +24,7 @@ func TestApiClient_GetAuroraDeploySpec(t *testing.T) {
 		defer ts.Close()
 
 		api := NewAPIClientDefaultRef(ts.URL, "test", affiliation)
-		spec, err := api.GetAuroraDeploySpec([]string{"aotest/redis"}, true)
+		spec, err := api.GetAuroraDeploySpec([]string{"aotest/redis"}, true, false)
 		assert.NoError(t, err)
 
 		assert.Len(t, spec, 1)
@@ -48,7 +48,7 @@ func TestApiClient_GetAuroraDeploySpecFormatted(t *testing.T) {
 		defer ts.Close()
 
 		api := NewAPIClientDefaultRef(ts.URL, "test", affiliation)
-		spec, err := api.GetAuroraDeploySpecFormatted("aotest", "redis", true)
+		spec, err := api.GetAuroraDeploySpecFormatted("aotest", "redis", true, false)
 		assert.NoError(t, err)
 
 		assert.Equal(t, string(expected), spec)
@@ -84,7 +84,7 @@ func Test_buildDeploySpecQueries(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := buildDeploySpecQueries(tt.applications, tt.defaults); !reflect.DeepEqual(len(got), tt.want) {
+			if got := buildDeploySpecQueries(tt.applications, tt.defaults, false); !reflect.DeepEqual(len(got), tt.want) {
 				t.Errorf("buildDeploySpecQueries() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/service/deploymentspec.go
+++ b/pkg/service/deploymentspec.go
@@ -7,7 +7,7 @@ import (
 
 // GetFilteredDeploymentSpecs gets a filtered array of deployment specifications
 func GetFilteredDeploymentSpecs(apiClient client.DeploySpecClient, applications []string, overrideCluster string) ([]deploymentspec.DeploymentSpec, error) {
-	deploySpecs, err := apiClient.GetAuroraDeploySpec(applications, true)
+	deploySpecs, err := apiClient.GetAuroraDeploySpec(applications, true, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Har innført flagget --ignore-errors for å undertrykke errors ved ao get spec.  Det skrives ut advarsler om at dette kan gi ufullstendig spec i hjelpetekst og når det benyttes.