### PR TITLE
Feature/aos 5325 vault secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ dirty-check:
 ifneq (,$(findstring dirty,$(VERSION)))
 	@echo "--- DEBUG START (Detected dirty version)"
 	@/bin/sh -c "git status"
-	@/bin/sh -c "git diff"
+	@/bin/sh -c "git --no-pager diff"
 	@echo "--- DEBUG END"
 endif
 

--- a/cmd/vault.go
+++ b/cmd/vault.go
@@ -134,16 +134,16 @@ func GetSecret(cmd *cobra.Command, args []string) error {
 	}
 	vaultName, secretName := split[0], split[1]
 
-	vault, err := DefaultAPIClient.GetVault(vaultName)
+	secret, err := DefaultAPIClient.GetSecret(vaultName, secretName)
+	if err != nil {
+		return err
+	}
+	decodedSecret, err := secret.DecodedSecret()
 	if err != nil {
 		return err
 	}
 
-	secret, err := vault.Secrets.GetSecret(secretName)
-	if err != nil {
-		return err
-	}
-	cmd.Printf("%s", secret)
+	cmd.Printf("%s", decodedSecret)
 	return nil
 }
 

--- a/cmd/vault.go
+++ b/cmd/vault.go
@@ -307,10 +307,6 @@ func DeleteSecret(cmd *cobra.Command, args []string) error {
 	}
 
 	vaultName, secret := split[0], split[1]
-	vault, err := DefaultAPIClient.GetVault(vaultName)
-	if err != nil {
-		return err
-	}
 
 	message := fmt.Sprintf("Do you want to delete secret %s in affiliation %s?", args[0], AO.Affiliation)
 	shouldDelete := prompt.Confirm(message, false)
@@ -318,9 +314,8 @@ func DeleteSecret(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	vault.Secrets.RemoveSecret(secret)
-
-	err = DefaultAPIClient.SaveVault(*vault)
+	secretNames := []string{secret}
+	err := DefaultAPIClient.RemoveSecrets(vaultName, secretNames)
 	if err != nil {
 		return err
 	}

--- a/cmd/vault.go
+++ b/cmd/vault.go
@@ -174,7 +174,6 @@ func RenameSecret(cmd *cobra.Command, args []string) error {
 	if len(args) != 2 {
 		return cmd.Usage()
 	}
-
 	split := strings.Split(args[0], "/")
 	if len(split) != 2 {
 		return errNotValidSecretArgument
@@ -182,25 +181,8 @@ func RenameSecret(cmd *cobra.Command, args []string) error {
 
 	newSecretName := args[1]
 	vaultName, secretName := split[0], split[1]
-	vault, err := DefaultAPIClient.GetVault(vaultName)
-	if err != nil {
-		return err
-	}
 
-	_, err = vault.Secrets.GetSecret(secretName)
-	if err != nil {
-		return err
-	}
-
-	_, ok := vault.Secrets[newSecretName]
-	if ok {
-		return errors.Errorf("Secret %s already exists\n", newSecretName)
-	}
-
-	vault.Secrets[newSecretName] = vault.Secrets[secretName]
-	vault.Secrets.RemoveSecret(secretName)
-
-	err = DefaultAPIClient.SaveVault(*vault)
+	err := DefaultAPIClient.RenameSecret(vaultName, secretName, newSecretName)
 	if err != nil {
 		return err
 	}

--- a/cmd/vault_test.go
+++ b/cmd/vault_test.go
@@ -21,25 +21,28 @@ func Test_collectSecrets(t *testing.T) {
 	secret := path.Join(vaultTestFolder, secretFile)
 
 	t.Run("should add secret latest.properties from given file to vault 'test'", func(t *testing.T) {
-		vault := client.NewAuroraSecretVault("test")
+		vault := client.NewVault("test")
 
-		err := collectSecrets(secret, vault, true)
+		err := collectVaultSecrets(secret, vault, true)
 		assert.NoError(t, err)
-
-		secret, err := vault.Secrets.GetSecret(secretFile)
+		assert.True(t, len(vault.Secrets) == 1)
+		secret := vault.Secrets[0]
+		decodedSecret, err := secret.DecodedSecret()
 		assert.NoError(t, err)
-		assert.Equal(t, "FOO=BAR\nBAZ=FOOBAR", secret)
+		assert.Equal(t, "FOO=BAR\nBAZ=FOOBAR", decodedSecret)
 	})
 
 	t.Run("should add secret and permission from given folder to vault 'test'", func(t *testing.T) {
-		vault := client.NewAuroraSecretVault("test")
+		vault := client.NewVault("test")
 
-		err := collectSecrets(vaultTestFolder, vault, true)
+		err := collectVaultSecrets(vaultTestFolder, vault, true)
 		assert.NoError(t, err)
 
-		secret, err := vault.Secrets.GetSecret(secretFile)
+		assert.True(t, len(vault.Secrets) == 1)
+		secret := vault.Secrets[0]
+		decodedSecret, err := secret.DecodedSecret()
 		assert.NoError(t, err)
-		assert.Equal(t, "FOO=BAR\nBAZ=FOOBAR", secret)
+		assert.Equal(t, "FOO=BAR\nBAZ=FOOBAR", decodedSecret)
 		assert.Equal(t, []string{"test_group"}, vault.Permissions)
 	})
 }

--- a/pkg/client/goboapi_test.go
+++ b/pkg/client/goboapi_test.go
@@ -54,7 +54,7 @@ func TestGoboApi(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		graphQlRequest := `query ($affiliation: String!, $testKey: String) {affiliations(name: $affiliation, test: $testKey) {{someDataStructure{someData}}`
+		graphQlRequest := `query ($affiliation: String!, $testKey: String) {affiliations(names: [$affiliation], test: $testKey) {{someDataStructure{someData}}`
 
 		type SomeResponse struct {
 			SomeDataStructure struct {

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -66,6 +66,13 @@ func (api *AffiliationsResponse) Secret(affiliation, vaultname, secretname strin
 	return nil
 }
 
+func NewSecret(name, base64content string) Secret {
+	return Secret{
+		Name:          name,
+		Base64Content: base64content,
+	}
+}
+
 func (secret *Secret) DecodedSecret() (string, error) {
 	data, err := base64.StdEncoding.DecodeString(secret.Base64Content)
 	if err != nil {

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -40,6 +40,10 @@ func NewVault(name string) *Vault {
 	}
 }
 
+func (vault *Vault) AddSecret(secret Secret) {
+	vault.Secrets = append(vault.Secrets, secret)
+}
+
 func (api *AffiliationsResponse) Vaults(affiliation string) []Vault {
 	for _, edge := range api.Affiliations.Edges {
 		if edge.Node.Name == affiliation {

--- a/pkg/client/model.go
+++ b/pkg/client/model.go
@@ -1,5 +1,7 @@
 package client
 
+import "encoding/base64"
+
 type AffiliationsResponse struct {
 	Affiliations Affiliation `json:"affiliations"`
 }
@@ -45,4 +47,29 @@ func (api *AffiliationsResponse) Vaults(affiliation string) []Vault {
 		}
 	}
 	return nil
+}
+
+func (api *AffiliationsResponse) Secret(affiliation, vaultname, secretname string) *Secret {
+	for _, edge := range api.Affiliations.Edges {
+		if edge.Node.Name == affiliation {
+			for _, vault := range edge.Node.Vaults {
+				if vault.Name == vaultname {
+					for _, secret := range vault.Secrets {
+						if secret.Name == secretname {
+							return &secret
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (secret *Secret) DecodedSecret() (string, error) {
+	data, err := base64.StdEncoding.DecodeString(secret.Base64Content)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }

--- a/pkg/client/vault.go
+++ b/pkg/client/vault.go
@@ -463,6 +463,43 @@ func (api *APIClient) AddSecrets(vaultName string, secrets []Secret) error {
 	return nil
 }
 
+type RemoveVaultSecretsInput struct {
+	AffiliationName string   `json:"affiliationName"`
+	SecretNames     []string `json:"secretNames"`
+	VaultName       string   `json:"vaultName"`
+}
+
+// RemoveVaultSecretsResponse is core of response from graphql removeVaultSecrets
+type RemoveVaultSecretsResponse = Vault
+
+const removeVaultSecretsRequestString = `mutation removeVaultSecrets ($removeVaultSecretsInput: RemoveVaultSecretsInput!){
+  removeVaultSecrets(input: $removeVaultSecretsInput)
+  {
+    name
+    secrets {
+		name
+	}
+  }
+}`
+
+// AddPermissions adds permissions to vault via gobo
+func (api *APIClient) RemoveSecrets(vaultName string, secretNames []string) error {
+	removeVaultSecretsRequest := graphql.NewRequest(removeVaultSecretsRequestString)
+	removeVaultSecretsInput := RemoveVaultSecretsInput{
+		AffiliationName: api.Affiliation,
+		SecretNames:     secretNames,
+		VaultName:       vaultName,
+	}
+	removeVaultSecretsRequest.Var("removeVaultSecretsInput", removeVaultSecretsInput)
+
+	var removeVaultSecretsResponse RemoveVaultSecretsResponse
+	if err := api.RunGraphQlMutation(removeVaultSecretsRequest, &removeVaultSecretsResponse); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // GetSecret gets a secret by name
 func (s Secrets) GetSecret(name string) (string, error) {
 	secret, found := s[name]

--- a/pkg/client/vault.go
+++ b/pkg/client/vault.go
@@ -10,7 +10,7 @@ const FoundNoSecretsForVault = "Found no secrets for vault"
 
 const queryGetVaults = `
 	query getVaults ($affiliation: String!) {
-			 affiliations(name: $affiliation) {
+			 affiliations(names: [$affiliation]) {
     			edges {
       				node {
         				name
@@ -45,7 +45,7 @@ func (api *APIClient) GetVaults() ([]Vault, error) {
 
 const queryGetSecretQuery = `
 	query getVaults ($affiliation: String!, $vaultname: [String!]!, $secretname: [String!]!) {
-		affiliations(name: $affiliation) {
+		affiliations(names: [$affiliation]) {
 			edges {
 				node {
 					name

--- a/pkg/client/vault.go
+++ b/pkg/client/vault.go
@@ -426,6 +426,44 @@ func (api *APIClient) DeleteVault(vaultName string) error {
 	return nil
 }
 
+type AddVaultSecretsInput struct {
+	AffiliationName string   `json:"affiliationName"`
+	Secrets         []Secret `json:"secrets"`
+	VaultName       string   `json:"vaultName"`
+}
+
+// AddVaultSecretsResponse is core of response from graphql addVaultSecrets
+type AddVaultSecretsResponse = Vault
+
+const addVaultSecretsRequestString = `mutation addVaultSecrets ($addVaultSecretsInput: AddVaultSecretsInput!){
+  addVaultSecrets(input: $addVaultSecretsInput)
+  {
+    name
+    secrets {
+		name
+		base64Content
+	}
+  }
+}`
+
+// AddPermissions adds permissions to vault via gobo
+func (api *APIClient) AddSecrets(vaultName string, secrets []Secret) error {
+	addVaultSecretsRequest := graphql.NewRequest(addVaultSecretsRequestString)
+	addVaultSecretsInput := AddVaultSecretsInput{
+		AffiliationName: api.Affiliation,
+		Secrets:         secrets,
+		VaultName:       vaultName,
+	}
+	addVaultSecretsRequest.Var("addVaultSecretsInput", addVaultSecretsInput)
+
+	var addVaultSecretsResponse AddVaultSecretsResponse
+	if err := api.RunGraphQlMutation(addVaultSecretsRequest, &addVaultSecretsResponse); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // GetSecret gets a secret by name
 func (s Secrets) GetSecret(name string) (string, error) {
 	secret, found := s[name]

--- a/pkg/client/vault.go
+++ b/pkg/client/vault.go
@@ -531,8 +531,47 @@ func (api *APIClient) RenameSecret(vaultName, oldSecretName, newSecretName strin
 	}
 	renameVaultSecretRequest.Var("renameVaultSecretInput", renameVaultSecretInput)
 
-	var removeVaultSecretsResponse RemoveVaultSecretsResponse
+	var removeVaultSecretsResponse RenameVaultSecretResponse
 	if err := api.RunGraphQlMutation(renameVaultSecretRequest, &removeVaultSecretsResponse); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type UpdateVaultSecretInput struct {
+	AffiliationName string `json:"affiliationName"`
+	Base64Content   string `json:"base64Content"`
+	SecretName      string `json:"secretName"`
+	VaultName       string `json:"vaultName"`
+}
+
+// UpdateVaultSecretResponse is core of response from graphql updateVaultSecret
+type UpdateVaultSecretResponse = Vault
+
+const updateVaultSecretRequestString = `mutation updateVaultSecret ($updateVaultSecretInput: UpdateVaultSecretInput!){
+  updateVaultSecret(input: $updateVaultSecretInput)
+  {
+    name
+    secrets {
+		name
+	}
+  }
+}`
+
+// UpdateSecret updates a secret in vault via gobo
+func (api *APIClient) UpdateSecret(vaultName, secretName, modifiedContent string) error {
+	updateVaultSecretRequest := graphql.NewRequest(updateVaultSecretRequestString)
+	updateVaultSecretInput := UpdateVaultSecretInput{
+		AffiliationName: api.Affiliation,
+		Base64Content:   base64.StdEncoding.EncodeToString([]byte(modifiedContent)),
+		SecretName:      secretName,
+		VaultName:       vaultName,
+	}
+	updateVaultSecretRequest.Var("updateVaultSecretInput", updateVaultSecretInput)
+
+	var updateVaultSecretsResponse UpdateVaultSecretResponse
+	if err := api.RunGraphQlMutation(updateVaultSecretRequest, &updateVaultSecretsResponse); err != nil {
 		return err
 	}
 

--- a/pkg/client/vault.go
+++ b/pkg/client/vault.go
@@ -441,7 +441,6 @@ const addVaultSecretsRequestString = `mutation addVaultSecrets ($addVaultSecrets
     name
     secrets {
 		name
-		base64Content
 	}
   }
 }`

--- a/pkg/client/vault.go
+++ b/pkg/client/vault.go
@@ -2,42 +2,11 @@ package client
 
 import (
 	"encoding/base64"
-	"encoding/json"
-	"fmt"
 	"github.com/pkg/errors"
 	"github.com/skatteetaten/graphql"
-	"net/http"
-	"strings"
 )
 
-type (
-	// Secrets is a key-value map of secrets
-	Secrets map[string]string
-
-	// AuroraSecretVault TODO: Deprecated.  Replace with Vault when Boober code is gone
-	AuroraSecretVault struct {
-		Name        string   `json:"name"`
-		Permissions []string `json:"permissions"`
-		Secrets     Secrets  `json:"secrets"`
-	}
-
-	// VaultFileResource holds contents from a vault file resource
-	VaultFileResource struct {
-		Contents string `json:"contents"`
-	}
-)
-
-const ErrorVaultNotFound = "Vault not found"
 const FoundNoSecretsForVault = "Found no secrets for vault"
-
-// NewAuroraSecretVault creates a new AuroraSecretVault
-func NewAuroraSecretVault(name string) *AuroraSecretVault {
-	return &AuroraSecretVault{
-		Name:        name,
-		Secrets:     make(Secrets),
-		Permissions: []string{},
-	}
-}
 
 const queryGetVaults = `
 	query getVaults ($affiliation: String!) {
@@ -115,28 +84,6 @@ func (api *APIClient) GetSecret(vaultname, secretname string) (*Secret, error) {
 	return secret, nil
 }
 
-// GetVault gets an aurora secret vault via API calls
-func (api *APIClient) GetVault(vaultName string) (*AuroraSecretVault, error) {
-	endpoint := fmt.Sprintf("/vault/%s/%s", api.Affiliation, vaultName)
-
-	response, err := api.Do(http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if response != nil && !response.Success && strings.Contains(response.Message, "Vault not found") {
-		return nil, errors.New(ErrorVaultNotFound)
-	}
-
-	var vault AuroraSecretVault
-	err = response.ParseFirstItem(&vault)
-	if err != nil {
-		return nil, err
-	}
-
-	return &vault, nil
-}
-
 type CreateVaultInput struct {
 	AffiliationName string   `json:"affiliationName"`
 	VaultName       string   `json:"vaultName"`
@@ -148,7 +95,7 @@ type CreateVaultResponse struct {
 	CreateVault Vault `json:"createVault"`
 }
 
-func (api *APIClient) CreateVault(vault AuroraSecretVault) error {
+func (api *APIClient) CreateVault(vault Vault) error {
 	if len(vault.Permissions) == 0 {
 		return errors.New("Aborted: Vault can not be created without permissions")
 	}
@@ -165,7 +112,6 @@ func (api *APIClient) CreateVault(vault AuroraSecretVault) error {
 	`
 
 	createVaultInput := mapCreateVaultInput(vault, api.Affiliation)
-
 	createVaultRequest := graphql.NewRequest(createVaultMutation)
 	createVaultRequest.Var("input", createVaultInput)
 
@@ -178,21 +124,12 @@ func (api *APIClient) CreateVault(vault AuroraSecretVault) error {
 	return nil
 }
 
-func mapCreateVaultInput(vault AuroraSecretVault, affiliation string) CreateVaultInput {
-	secrets := make([]Secret, len(vault.Secrets))
-	i := 0
-	for key, content := range vault.Secrets {
-		secrets[i] = Secret{
-			Base64Content: content,
-			Name:          key,
-		}
-		i++
-	}
+func mapCreateVaultInput(vault Vault, affiliation string) CreateVaultInput {
 	createVaultInput := CreateVaultInput{
 		AffiliationName: affiliation,
 		Permissions:     vault.Permissions,
 		VaultName:       vault.Name,
-		Secrets:         secrets,
+		Secrets:         vault.Secrets,
 	}
 	return createVaultInput
 }
@@ -227,91 +164,6 @@ func (api *APIClient) RenameVault(oldVaultName, newVaultName string) error {
 
 	if err := api.RunGraphQlMutation(renameVaultRequest, &createVaultResponse); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-// SaveVault saves an aurora secret vault via API calls
-func (api *APIClient) SaveVault(vault AuroraSecretVault) error {
-	if len(vault.Permissions) == 0 {
-		return errors.New("Aborted: Vault can not be saved without permissions")
-	}
-
-	endpoint := fmt.Sprintf("/vault/%s", api.Affiliation)
-
-	data, err := json.Marshal(vault)
-	if err != nil {
-		return err
-	}
-
-	response, err := api.Do(http.MethodPut, endpoint, data)
-	if err != nil {
-		return err
-	}
-
-	if !response.Success {
-		return errors.New(response.Message)
-	}
-
-	return nil
-}
-
-// GetSecretFile gets a secret file via API calls
-func (api *APIClient) GetSecretFile(vault, secret string) (string, string, error) {
-	endpoint := fmt.Sprintf("/vault/%s/%s/%s", api.Affiliation, vault, secret)
-
-	bundle, err := api.DoWithHeader(http.MethodGet, endpoint, nil, nil)
-	if err != nil || bundle == nil {
-		return "", "", err
-	}
-
-	if !bundle.BooberResponse.Success {
-		return "", "", errors.New(bundle.BooberResponse.Message)
-	}
-
-	var vaultFile VaultFileResource
-	err = bundle.BooberResponse.ParseFirstItem(&vaultFile)
-	if err != nil {
-		return "", "", nil
-	}
-
-	data, err := base64.StdEncoding.DecodeString(vaultFile.Contents)
-	if err != nil {
-		return "", "", err
-	}
-
-	eTag := bundle.HTTPResponse.Header.Get("ETag")
-
-	return string(data), eTag, nil
-}
-
-// UpdateSecretFile updates a secret file via API calls
-func (api *APIClient) UpdateSecretFile(vault, secret, eTag string, content []byte) error {
-	endpoint := fmt.Sprintf("/vault/%s/%s/%s", api.Affiliation, vault, secret)
-
-	encoded := base64.StdEncoding.EncodeToString(content)
-
-	header := map[string]string{
-		"If-Match": eTag,
-	}
-
-	vaultFile := VaultFileResource{
-		Contents: encoded,
-	}
-
-	data, err := json.Marshal(vaultFile)
-	if err != nil {
-		return err
-	}
-
-	bundle, err := api.DoWithHeader(http.MethodPut, endpoint, header, data)
-	if err != nil || bundle == nil {
-		return err
-	}
-
-	if !bundle.BooberResponse.Success {
-		return errors.New(bundle.BooberResponse.Message)
 	}
 
 	return nil
@@ -576,29 +428,4 @@ func (api *APIClient) UpdateSecret(vaultName, secretName, modifiedContent string
 	}
 
 	return nil
-}
-
-// GetSecret gets a secret by name
-func (s Secrets) GetSecret(name string) (string, error) {
-	secret, found := s[name]
-	if !found {
-		return "", errors.Errorf("Did not find secret %s", name)
-	}
-	data, err := base64.StdEncoding.DecodeString(secret)
-	if err != nil {
-		return "", err
-	}
-
-	return string(data), nil
-}
-
-// AddSecret adds a secret
-func (s Secrets) AddSecret(name, content string) {
-	encoded := base64.StdEncoding.EncodeToString([]byte(content))
-	s[name] = encoded
-}
-
-// RemoveSecret deletes a secret
-func (s Secrets) RemoveSecret(name string) {
-	delete(s, name)
 }

--- a/pkg/client/vault.go
+++ b/pkg/client/vault.go
@@ -445,7 +445,7 @@ const addVaultSecretsRequestString = `mutation addVaultSecrets ($addVaultSecrets
   }
 }`
 
-// AddPermissions adds permissions to vault via gobo
+// AddSecrets adds secrets to vault via gobo
 func (api *APIClient) AddSecrets(vaultName string, secrets []Secret) error {
 	addVaultSecretsRequest := graphql.NewRequest(addVaultSecretsRequestString)
 	addVaultSecretsInput := AddVaultSecretsInput{
@@ -482,7 +482,7 @@ const removeVaultSecretsRequestString = `mutation removeVaultSecrets ($removeVau
   }
 }`
 
-// AddPermissions adds permissions to vault via gobo
+// RemoveSecrets removes secrets from vault via gobo
 func (api *APIClient) RemoveSecrets(vaultName string, secretNames []string) error {
 	removeVaultSecretsRequest := graphql.NewRequest(removeVaultSecretsRequestString)
 	removeVaultSecretsInput := RemoveVaultSecretsInput{
@@ -494,6 +494,45 @@ func (api *APIClient) RemoveSecrets(vaultName string, secretNames []string) erro
 
 	var removeVaultSecretsResponse RemoveVaultSecretsResponse
 	if err := api.RunGraphQlMutation(removeVaultSecretsRequest, &removeVaultSecretsResponse); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type RenameVaultSecretInput struct {
+	AffiliationName string `json:"affiliationName"`
+	NewSecretName   string `json:"newSecretName"`
+	SecretName      string `json:"secretName"`
+	VaultName       string `json:"vaultName"`
+}
+
+// RenameVaultSecretResponse is core of response from graphql renameVaultSecret
+type RenameVaultSecretResponse = Vault
+
+const renameVaultSecretRequestString = `mutation renameVaultSecret ($renameVaultSecretInput: RenameVaultSecretInput!){
+  renameVaultSecret(input: $renameVaultSecretInput)
+  {
+    name
+    secrets {
+		name
+	}
+  }
+}`
+
+// RenameSecret renames a secret in vault via gobo
+func (api *APIClient) RenameSecret(vaultName, oldSecretName, newSecretName string) error {
+	renameVaultSecretRequest := graphql.NewRequest(renameVaultSecretRequestString)
+	renameVaultSecretInput := RenameVaultSecretInput{
+		AffiliationName: api.Affiliation,
+		NewSecretName:   newSecretName,
+		SecretName:      oldSecretName,
+		VaultName:       vaultName,
+	}
+	renameVaultSecretRequest.Var("renameVaultSecretInput", renameVaultSecretInput)
+
+	var removeVaultSecretsResponse RemoveVaultSecretsResponse
+	if err := api.RunGraphQlMutation(renameVaultSecretRequest, &removeVaultSecretsResponse); err != nil {
 		return err
 	}
 

--- a/pkg/client/vault_test.go
+++ b/pkg/client/vault_test.go
@@ -72,10 +72,7 @@ func TestAPIClient_CreateVault(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		secret := Secret{
-			Name:          "latest.properties",
-			Base64Content: "YWJjMTIz",
-		}
+		secret := NewSecret("latest.properties", "YWJjMTIz")
 		newVault := Vault{
 			Name:        "test-vault",
 			Permissions: []string{"utv"},
@@ -97,10 +94,7 @@ func TestAPIClient_CreateVault(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		secret := Secret{
-			Name:          "latest.properties",
-			Base64Content: "YWJjMTIz",
-		}
+		secret := NewSecret("latest.properties", "YWJjMTIz")
 		newVault := NewVault("my_test_vault")
 		newVault.Secrets = []Secret{secret}
 		newVault.Permissions = []string{"utv_permission"}
@@ -118,10 +112,7 @@ func TestAPIClient_CreateVault(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		secret := Secret{
-			Name:          "latest.properties",
-			Base64Content: "YWJjMTIz",
-		}
+		secret := NewSecret("latest.properties", "YWJjMTIz")
 		newVault := NewVault("my_test_vault")
 		newVault.Secrets = []Secret{secret}
 		newVault.Permissions = []string{"utv_permission"}

--- a/pkg/client/vault_test.go
+++ b/pkg/client/vault_test.go
@@ -435,3 +435,20 @@ func TestAPIClient_RenameSecret(t *testing.T) {
 		assert.Contains(t, err.Error(), api.Korrelasjonsid)
 	})
 }
+
+func TestAPIClient_UpdateSecret(t *testing.T) {
+	t.Run("Should update a secret", func(t *testing.T) {
+		response := []byte(`{"data":{"updateVaultSecret":{"name":"my_test_vault","secrets":[{"name":"secret.txt"}]}}}`)
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write(response)
+		}))
+		defer ts.Close()
+
+		api := NewAPIClientDefaultRef("", ts.URL, "test", affiliation, "")
+		err := api.UpdateSecret("my_test_vault", "secret.txt", "newcontent")
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Inneholder fikser for resten av ao vault *, slik at alle ao vault-kall går mot gobo.

Gammel kode er ryddet vekk.