### PR TITLE
AOS-5644 added utv-relay01 and test-relay01

### DIFF
--- a/pkg/config/ao.go
+++ b/pkg/config/ao.go
@@ -155,7 +155,7 @@ func (ao *AOConfig) AddMultipleClusterConfig() {
 		},
 	}
 
-	ocp4Clusters := []string{"prod01", "test01", "utv04"}
+	ocp4Clusters := []string{"prod01", "test01", "utv04", "utv-relay01", "test-relay01"}
 	for _, cluster := range ocp4Clusters {
 		ao.AvailableClusters = append(ao.AvailableClusters, cluster)
 		ao.PreferredAPIClusters = append([]string{cluster}, ao.PreferredAPIClusters...)


### PR DESCRIPTION
Kan testes ved å kjøre ao adm recreate-config --beta-multiple-cluster-types og se at man får innslag for test-relay01 og utv-relay01 i .ao.json 