### PR TITLE
feature/AOS-5883-show-error-type-in-error-message

### DIFF
--- a/pkg/client/response.go
+++ b/pkg/client/response.go
@@ -157,7 +157,7 @@ func (e *ErrorResponse) getAllErrors() []string {
 func (e *ErrorResponse) formatValidationError(res *responseErrorItem) {
 	illegalFieldFormat := `Application: %s/%s
 Filename:    %s
-Field:       %s
+Field:       %s (Illegal)
 Value:       %s
 Message:     %s`
 
@@ -167,7 +167,7 @@ Message:     %s`
 
 	invalidFieldFormat := `Application: %s/%s
 Filename:    %s
-Field:       %s
+Field:       %s (Invalid)
 Message:     %s`
 
 	genericFormat := `Application: %s/%s


### PR DESCRIPTION
Eksempel med endringen bold tekst

Application: utv03/gobo
Filename:    gobo.yaml 
Field:       env/ttl **(Illegal)**
Value:       2d
Message:     Invalid Source field=env/ttl. Actual source=gobo.yaml (File type: BASE). Must be placed within files of type: [GLOBAL, ENV, INCLUDE_ENV]