### PR TITLE
AOS-5949 remove beta flag and add ao adm default-apicluster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ def overrides = [
     nodeVersion: "12",
     applicationType: "nodejs",
     versionStrategy: [
-      [ branch: 'master', versionHint: '3' ]
+      [ branch: 'master', versionHint: '4' ]
     ]
 ]
 

--- a/cmd/adm.go
+++ b/cmd/adm.go
@@ -195,7 +195,10 @@ func SetApiCluster(cmd *cobra.Command, args []string) error {
 	}
 
 	newApiCluster := args[0]
-	// TODO: Validate that newApiCluster is a valid cluster
+	// Validate that newApiCluster is a valid cluster
+	if _, ok := AO.Clusters[newApiCluster]; !ok {
+		return fmt.Errorf("Failed to set default apicluster, %s is not a valid cluster", newApiCluster)
+	}
 
 	AO.APICluster = newApiCluster
 	if err := config.WriteConfig(*AO, ConfigLocation); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,6 +88,8 @@ func initialize(cmd *cobra.Command, args []string) error {
 		logrus.Error(err)
 	}
 
+	cmdIsRecreateConfig := strings.Contains(cmd.Name(), recreateConfigCmd.Use)
+
 	if aoConfig == nil {
 		logrus.Info("Creating new config")
 		aoConfig = &config.DefaultAOConfig
@@ -97,7 +99,7 @@ func initialize(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-	} else if aoConfig.FileAOVersion != config.Version {
+	} else if !cmdIsRecreateConfig && aoConfig.FileAOVersion != config.Version {
 		logrus.Debugf("ao config file is saved with another versjon. AO-version: %s, saved version: %s", config.Version, aoConfig.FileAOVersion)
 
 		if update() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,6 +93,7 @@ func initialize(cmd *cobra.Command, args []string) error {
 	if aoConfig == nil {
 		logrus.Info("Creating new config")
 		aoConfig = &config.DefaultAOConfig
+		aoConfig.AddMultipleClusterConfig()
 		aoConfig.InitClusters()
 		aoConfig.SelectAPICluster()
 		err = config.WriteConfig(*aoConfig, ConfigLocation)

--- a/pkg/config/ao.go
+++ b/pkg/config/ao.go
@@ -156,7 +156,9 @@ func (ao *AOConfig) AddMultipleClusterConfig() {
 	}
 	ocp4Clusters := []string{"utv04", "utv-relay01", "test01", "test-relay01", "prod01", "prod-relay01"}
 	for _, cluster := range ocp4Clusters {
-		ao.AvailableClusters = append(ao.AvailableClusters, cluster)
+		if !contains(ao.AvailableClusters, cluster) {
+			ao.AvailableClusters = append(ao.AvailableClusters, cluster)
+		}
 		ao.ClusterConfig[cluster] = &ClusterConfig{
 			Type: "ocp4",
 		}
@@ -177,6 +179,16 @@ func formatNonLocalhostPattern(pattern string, a ...interface{}) string {
 	}
 
 	return fmt.Sprintf(pattern, a...)
+}
+
+// Checks if a string slice contains a string
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
 }
 
 // LoadConfigFile loads an AOConfig file from file system


### PR DESCRIPTION
Fase ut behovet for --beta-multiple-cluster-types-flagget 
I overgangsfasen innføres et flagg --only-ocp3-clusters som gir gammel config som en nød-fallback.
Begge disse flaggene er hidden.

Kommandoen ao adm default-apicluster <cluster> er lagt til.