### PR TITLE
AOS-6211 filtering out unwanted fuzzy matches

### DIFF
--- a/pkg/auroraconfig/fuzzy_test.go
+++ b/pkg/auroraconfig/fuzzy_test.go
@@ -21,10 +21,12 @@ var fileNames = FileNames{
 	"test/console.json",
 	"test-relay/about.json",
 	"test-relay/boober.json",
+	"test-relay/app2.yaml",
 }
 
 func TestFilterFileNamesForDeploy(t *testing.T) {
 	var expected = []string{
+		"test-relay/app2",
 		"test-relay/boober",
 		"test/boober",
 		"test/console",
@@ -53,11 +55,16 @@ func TestFindMatches(t *testing.T) {
 		{"utv/ab", true, []string{"utv/about.json", "utv-relay/about.json", "utv/about-template.json"}},
 		{"utv/o", true, []string{"utv/about.json", "utv/boober.json", "utv/console.json",
 			"utv-relay/about.json", "utv-relay/boober.json", "utv/about-template.json"}},
+		{"testboober", false, []string{}},
+		{"test/boo", false, []string{"test/boober", "test-relay/boober"}},
+		{"test-relay2", false, []string{}},
+		{"test-relay2/app2", false, []string{}},
+		{"test-relay/app2", false, []string{"test-relay/app2"}},
 	}
 
 	for _, test := range tests {
 		matches := FindMatches(test.Search, fileNames, test.WithSuffix)
-		assert.Equal(t, test.Expected, matches, test.Search+" returned unexpected matches than expected.")
+		assert.Equal(t, test.Expected, matches, test.Search+" returned other matches than expected.")
 	}
 }
 
@@ -69,6 +76,7 @@ func TestFindFileToEdit(t *testing.T) {
 		{"about", []string{"about.json"}},
 		{"console", []string{"console.json"}},
 		{"utv/ab", []string{"utv/about.json", "utv-relay/about.json", "utv/about-template.json"}},
+		{"test-relay2", []string{}},
 	}
 
 	for _, test := range tests {
@@ -86,9 +94,10 @@ func TestFindApplicationsToDeploy(t *testing.T) {
 		{"utv", []string{"utv/boober", "utv/console"}},
 		{"console", []string{"test/console", "utv/console"}},
 		{"test", []string{"test/boober", "test/console"}},
-		{"test-r", []string{"test-relay/boober"}},
+		{"test-r", []string{"test-relay/app2", "test-relay/boober"}},
 		{"boober", []string{"test/boober", "test-relay/boober", "utv/boober", "utv-relay/boober"}},
 		{"boo", []string{"utv/boober", "test/boober", "utv-relay/boober", "test-relay/boober"}},
+		{"test-relay2", []string{}},
 	}
 
 	filteredFiles := fileNames.GetApplicationDeploymentRefs()
@@ -111,6 +120,7 @@ func TestFindAllFor(t *testing.T) {
 		{"test-r", EnvFilter, []string{}},
 		{"boober", AppFilter, []string{"test/boober", "test-relay/boober", "utv/boober", "utv-relay/boober"}},
 		{"boo", AppFilter, []string{}},
+		{"test-relay2", AppFilter, []string{}},
 	}
 
 	filteredFiles := fileNames.GetApplicationDeploymentRefs()


### PR DESCRIPTION
Removes unwanted matches. Example: "k17633-test2" should not match "k17633-test/jenkins-slave-node12". See AOS-6211 for further explanation.