### PR TITLE
AOS-6467 Added utv05 to standard clusters

### DIFF
--- a/pkg/config/aoconfig.go
+++ b/pkg/config/aoconfig.go
@@ -13,7 +13,7 @@ const OCP3 = "ocp3"
 const OCP4 = "ocp4"
 
 var ocp3Clusters = []string{"utv", "utv-relay", "test", "test-relay", "prod", "prod-relay"}
-var ocp4Clusters = []string{"utv04", "utv-relay01", "test01", "test-relay01", "prod01", "prod-relay01", "log01"}
+var ocp4Clusters = []string{"utv04", "utv05", "utv-relay01", "test01", "test-relay01", "prod01", "prod-relay01", "log01"}
 var availableUpdateClusters = []string{"utv", "test", "utv04", "test01"}
 
 // ServiceURLPatterns contains url patterns for all integrations made with AO.


### PR DESCRIPTION
Er testet med ao login.  Det er viktig at boober og gobo er stabilt oppe på utv05 før denne merges inn og tilgjengeliggjøres.