### PR TITLE
feature/aos 6696 prefer ocp4 clusters

### DIFF
--- a/cmd/adm.go
+++ b/cmd/adm.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/skatteetaten/ao/pkg/session"
 	"os"
+	"strings"
 
 	"github.com/skatteetaten/ao/pkg/versioncontrol"
 
@@ -213,7 +214,7 @@ func SetApiCluster(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed to set default apicluster, %s is not a valid cluster", newApiCluster)
 	}
 
-	AOSession.APICluster = newApiCluster
+	AOSession.APICluster = strings.TrimSpace(newApiCluster)
 	if err := session.WriteAOSession(*AOSession, SessionFileLocation); err != nil {
 		return err
 	}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -101,7 +101,7 @@ func Login(cmd *cobra.Command, args []string) error {
 		if _, ok := AOConfig.Clusters[flagAPICluster]; !ok {
 			return errors.Errorf("%s is not a valid cluster option. Choose between %v", flagAPICluster, AOConfig.AvailableClusters)
 		}
-		AOSession.APICluster = flagAPICluster
+		AOSession.APICluster = strings.TrimSpace(flagAPICluster)
 	}
 
 	cluster := AOConfig.Clusters[AOSession.APICluster]

--- a/pkg/client/goboapi.go
+++ b/pkg/client/goboapi.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/sirupsen/logrus"
+	"github.com/skatteetaten/ao/pkg/config"
 	"github.com/skatteetaten/graphql"
 	"net/http"
 	"strconv"
@@ -36,7 +37,7 @@ func (api *APIClient) RunGraphQlMutation(graphQlRequest *graphql.Request, respon
 	graphQlRequest.Header.Set("Cache-Control", "no-cache")
 	graphQlRequest.Header.Add("Authorization", "Bearer "+api.Token)
 	graphQlRequest.Header.Add("Korrelasjonsid", api.Korrelasjonsid)
-	graphQlRequest.Header.Add("Klientid", "ao")
+	graphQlRequest.Header.Add("Klientid", "ao/"+config.Version)
 
 	if err := client.Run(ctx, graphQlRequest, response); err != nil {
 		extractederr := extractGraphqlErrorMsgs(err)
@@ -56,7 +57,7 @@ func (api *APIClient) newRequest(graphqlRequest string) *graphql.Request {
 	req := graphql.NewRequest(graphqlRequest)
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Add("Korrelasjonsid", api.Korrelasjonsid)
-	req.Header.Add("Klientid", "ao")
+	req.Header.Add("Klientid", "ao/"+config.Version)
 	req.Header.Add("Authorization", "Bearer "+api.Token)
 
 	return req

--- a/pkg/config/aoconfig.go
+++ b/pkg/config/aoconfig.go
@@ -115,7 +115,7 @@ func createMultipleClusterConfig() *AOConfig {
 	aoConfig := AOConfig{
 		Clusters:                make(map[string]*Cluster),
 		AvailableClusters:       append(ocp3Clusters, ocp4Clusters...),
-		PreferredAPIClusters:    []string{"utv04", "test01", "utv", "test"},
+		PreferredAPIClusters:    []string{"utv04", "utv05", "test01", "utv", "test"},
 		AvailableUpdateClusters: availableUpdateClusters,
 		FileAOVersion:           Version,
 	}

--- a/pkg/config/aoconfig.go
+++ b/pkg/config/aoconfig.go
@@ -115,7 +115,7 @@ func createMultipleClusterConfig() *AOConfig {
 	aoConfig := AOConfig{
 		Clusters:                make(map[string]*Cluster),
 		AvailableClusters:       append(ocp3Clusters, ocp4Clusters...),
-		PreferredAPIClusters:    []string{"utv", "test", "utv04", "test01"},
+		PreferredAPIClusters:    []string{"utv04", "test01", "utv", "test"},
 		AvailableUpdateClusters: availableUpdateClusters,
 		FileAOVersion:           Version,
 	}

--- a/pkg/config/aoconfig.go
+++ b/pkg/config/aoconfig.go
@@ -12,7 +12,7 @@ import (
 const OCP3 = "ocp3"
 const OCP4 = "ocp4"
 
-var ocp3Clusters = []string{"utv", "test", "test-relay", "prod", "prod-relay"}
+var ocp3Clusters = []string{"test", "test-relay", "prod", "prod-relay"}
 var ocp4Clusters = []string{"utv04", "utv05", "utv-relay01", "test01", "test-relay01", "prod01", "prod-relay01", "log01"}
 var availableUpdateClusters = []string{"utv04", "test01"}
 
@@ -115,7 +115,7 @@ func createMultipleClusterConfig() *AOConfig {
 	aoConfig := AOConfig{
 		Clusters:                make(map[string]*Cluster),
 		AvailableClusters:       append(ocp3Clusters, ocp4Clusters...),
-		PreferredAPIClusters:    []string{"utv04", "utv05", "test01", "utv", "test"},
+		PreferredAPIClusters:    []string{"utv04", "utv05", "test01", "test"},
 		AvailableUpdateClusters: availableUpdateClusters,
 		FileAOVersion:           Version,
 	}
@@ -178,13 +178,13 @@ func (aoConfig *AOConfig) SelectAPICluster() string {
 		}
 
 		if cluster.Reachable {
-			return name
+			return strings.TrimSpace(name)
 		}
 	}
 
 	for clusterName, cluster := range aoConfig.Clusters {
 		if cluster.Reachable {
-			return clusterName
+			return strings.TrimSpace(clusterName)
 		}
 	}
 	return ""

--- a/pkg/config/aoconfig_test.go
+++ b/pkg/config/aoconfig_test.go
@@ -25,9 +25,11 @@ func TestAOConfig_SelectApiCluster(t *testing.T) {
 		Clusters map[string]bool
 		Expected string
 	}{
-		{map[string]bool{"prod": true, "utv": true, "test": true, "qa": true}, "utv"},
-		{map[string]bool{"utv": false, "test": true, "qa": true}, "test"},
-		{map[string]bool{"qa": true, "test": false, "utv": false}, "qa"},
+		{map[string]bool{"prod01": true, "utv04": true, "test01": true, "utv05": true}, "utv04"},
+		{map[string]bool{"utv04": false, "test01": true}, "test01"},
+		{map[string]bool{"test01": false, "utv05": false, "test": true}, "test"},
+		{map[string]bool{"test02": false, "utv01": true}, "utv01"},
+		{map[string]bool{"test02": false, "utv04": false, "utv01": false}, ""},
 	}
 
 	for _, test := range tests {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -41,6 +41,10 @@ func LoadOrCreateAOSessionFile(sessionFileLocation string, aoConfig *config.AOCo
 			Tokens:       map[string]string{},
 		}
 		WriteAOSession(*aoSession, sessionFileLocation)
+	} else if len(aoSession.APICluster) == 0 {
+		aoSession.APICluster = aoConfig.SelectAPICluster()
+		WriteAOSession(*aoSession, sessionFileLocation)
+		logrus.Info("Auto-selected apicluster.")
 	}
 	return aoSession, nil
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/skatteetaten/ao/pkg/config"
 	"io/ioutil"
+	"strings"
 )
 
 // SessionFileLocation is the location of the file holding session data for the login session
@@ -41,7 +42,7 @@ func LoadOrCreateAOSessionFile(sessionFileLocation string, aoConfig *config.AOCo
 			Tokens:       map[string]string{},
 		}
 		WriteAOSession(*aoSession, sessionFileLocation)
-	} else if len(aoSession.APICluster) == 0 {
+	} else if len(strings.TrimSpace(aoSession.APICluster)) == 0 {
 		aoSession.APICluster = aoConfig.SelectAPICluster()
 		WriteAOSession(*aoSession, sessionFileLocation)
 		logrus.Info("Auto-selected apicluster.")
@@ -60,6 +61,8 @@ func LoadSessionFile(sessionFileLocation string) (*AOSession, error) {
 	err = json.Unmarshal(raw, &aoSession)
 	if err != nil {
 		return nil, err
+	} else {
+		aoSession.APICluster = strings.TrimSpace(aoSession.APICluster)
 	}
 
 	return aoSession, nil


### PR DESCRIPTION
Denne saken gjør følgende:
- Endrer rekkefølge som ao søker etter apiCluster fra (utv, test, utv04, test01) til (utv04, utv05, test01, utv, test)
- Gjør oppslag etter apiCluster dersom .ao-session.json har tom streng for apicluster.
- Forbedrer Klientid med versjon (AOS-6692)