### PR TITLE
feature/AOS-6937 adding --apicluster as global flag

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -75,6 +75,10 @@ func init() {
 }
 
 func deploy(cmd *cobra.Command, args []string) error {
+	apiCluster := flagCluster
+	if len(strings.TrimSpace(pFlagAPICluster)) > 0 {
+		apiCluster = strings.TrimSpace(pFlagAPICluster)
+	}
 
 	if len(args) > 2 || len(args) < 1 {
 		return cmd.Usage()
@@ -95,7 +99,7 @@ func deploy(cmd *cobra.Command, args []string) error {
 		auroraConfigName = flagAuroraConfig
 	}
 
-	apiClient, err := getAPIClient(auroraConfigName, pFlagToken, flagCluster)
+	apiClient, err := getAPIClient(auroraConfigName, pFlagToken, apiCluster)
 	if err != nil {
 		return err
 	}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -19,10 +19,9 @@ import (
 const supportedAPIVersion = 2
 
 var (
-	flagPassword   string
-	flagUserName   string
-	flagLocalhost  bool
-	flagAPICluster string
+	flagPassword  string
+	flagUserName  string
+	flagLocalhost bool
 )
 
 var loginCmd = &cobra.Command{
@@ -55,7 +54,6 @@ func init() {
 	loginCmd.Flags().StringVarP(&flagPassword, "password", "", "", "the password to log in with, if not set will prompt.  Should only be used in combination with a capturing function to avoid beeing shown in history files")
 	loginCmd.Flags().BoolVarP(&flagLocalhost, "localhost", "", false, "set api to localhost")
 	loginCmd.Flags().MarkHidden("localhost")
-	loginCmd.Flags().StringVarP(&flagAPICluster, "apicluster", "", "", "select specified API cluster")
 }
 
 // PreLogin performs pre command validation checks for the `login` cli command
@@ -96,6 +94,8 @@ func Login(cmd *cobra.Command, args []string) error {
 	if AOSession.Localhost != flagLocalhost {
 		AOSession.Localhost = flagLocalhost
 	}
+
+	flagAPICluster := strings.TrimSpace(pFlagAPICluster)
 
 	if flagAPICluster != "" {
 		if _, ok := AOConfig.Clusters[flagAPICluster]; !ok {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ var (
 	pFlagToken                string
 	pFlagRefName              string
 	pFlagNoHeader             bool
+	pFlagAPICluster           string
 	pFlagAnswerRecreateConfig string // deprecated
 
 	// DefaultAPIClient will use APICluster from ao config as default values
@@ -57,6 +58,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&pFlagToken, "token", "t", "", "OpenShift authorization token to use for remote commands, overrides login")
 	RootCmd.PersistentFlags().StringVar(&pFlagRefName, "ref", "", "Set git ref name, does not affect vaults")
 	RootCmd.PersistentFlags().BoolVar(&pFlagNoHeader, "no-headers", false, "Print tables without headers")
+	RootCmd.PersistentFlags().StringVarP(&pFlagAPICluster, "apicluster", "", "", "specify API cluster for this command, persistent when used with login")
 	RootCmd.PersistentFlags().MarkHidden("no-headers")
 	RootCmd.PersistentFlags().StringVar(&pFlagAnswerRecreateConfig, "autoanswer-recreate-config", "", "deprecated")
 	RootCmd.PersistentFlags().MarkHidden("autoanswer-recreate-config")
@@ -102,10 +104,17 @@ func initialize(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	apiCluster := aoConfig.Clusters[aoSession.APICluster]
+	var apiClusterName string
+	if len(strings.TrimSpace(pFlagAPICluster)) > 0 {
+		apiClusterName = strings.TrimSpace(pFlagAPICluster)
+	} else {
+		apiClusterName = aoSession.APICluster
+	}
+	apiCluster := aoConfig.Clusters[apiClusterName]
+
 	if apiCluster == nil {
 		if !strings.Contains(cmd.CommandPath(), "adm") {
-			return errors.Errorf("api cluster %s is not available. Try again later.", aoSession.APICluster)
+			return errors.Errorf("api cluster %s is not available. Try again later.", apiClusterName)
 		}
 		apiCluster = &config.Cluster{}
 	}


### PR DESCRIPTION
Denne saken gjør at vi i scripts kan frigjøre ao deploy fra .ao-session.json når det gjelder apicluster i tillegg til token. Vi gjør --apicluster global, slik at alle kall som går mot boober og gobo fra ao kan styres til riktig cluster.